### PR TITLE
Remove anything after '/' on the hash to allow deeplinking

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -886,6 +886,15 @@
                 } else {
                     // load a div
                     what = target.replace("#", "");
+
+                    var slashIndex = what.indexOf('/');
+                    var hashLink = "";
+                    if (slashIndex != -1) {
+                        // Ignore everything after the slash for loading
+                        hashLink = what.substr(slashIndex);
+                        what = what.substr(0, slashIndex);
+                    }
+
                     what = $am(what);
                     
                     if (!what)
@@ -920,8 +929,9 @@
                         });
                     }
                     try {
-                        window.history.pushState(what.id, what.id, startPath + "#" + what.id);
-                        $(window).trigger("hashchange", {newUrl: startPath + "#" + what.id,oldURL: startPath + "#" + oldDiv.id});
+                        var oldTarget = window.location.hash;
+                        window.history.pushState(what.id, what.id, startPath + '#' + what.id + hashLink);
+                        $(window).trigger("hashchange", {newUrl: startPath + '#' + what.id + hashLink,oldURL: startPath + oldTarget});
                     } 
                     catch (e) {
                     }


### PR DESCRIPTION
On the hash, we remove anything after a '/' so we can create links with a format like "#contact/28374".
contact will trigger the correct panel and anything after the / will be ignored and used by any application internally.
This would also allow users to bookmark pages from the application that contain all the needed information necessary for the app to reload (like a user id, a session id, etc).
