### PR TITLE
Do not use window.location.hash as it is updated at a different time in different browsers

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -8,6 +8,7 @@
     var hasLaunched = false;
     var startPath = window.location.pathname;
     var defaultHash = window.location.hash;
+    var previousTarget = defaultHash;
     var ui = function() {
         // Init the page
         var that = this;
@@ -927,7 +928,6 @@
                     if (oldDiv == currWhat) //prevent it from going to itself
                         return;
                     
-                    var oldTarget = window.location.hash;
                     if (newTab) {
                         this.history = [];
                         this.history.push({
@@ -936,17 +936,18 @@
                         });
                     } else if (!back) {
                         this.history.push({
-                            target: this.activeDiv.id,
+                            target: previousTarget,
                             transition: transition
                         });
                     }
                     try {
                         window.history.pushState(what.id, what.id, startPath + '#' + what.id + hashLink);
-                        $(window).trigger("hashchange", {newUrl: startPath + '#' + what.id + hashLink,oldURL: startPath + oldTarget});
+                        $(window).trigger("hashchange", {newUrl: startPath + '#' + what.id + hashLink,oldURL: startPath + previousTarget});
                     } 
                     catch (e) {
                     }
                     
+                    previousTarget = '#' + what.id + hashLink;
                     
                     if (this.resetScrollers && this.scrollingDivs[what.id]) {
                         this.scrollingDivs[what.id].scrollTo({


### PR DESCRIPTION
Hi Ian,

I did a small change to the previous patch that should solve the navigation issues on Android. Instead of relaying on window.location.hash, I keep the previous hash on a variable so we can control when is updated.
Please have a look and let me know if you need any other changes.

Thanks!
