### PR TITLE
Restore removed loadDefaultHash

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -1170,7 +1170,7 @@
                         that.titleBar.innerHTML = that.activeDiv.title;
                     that.parsePanelFunctions(that.activeDiv);
                     //Load the default hash
-                    if (defaultHash.length > 0) 
+                    if (defaultHash.length > 0 && that.loadDefaultHash) 
                     {
                         that.loadContent(defaultHash);
                     }


### PR DESCRIPTION
Hey Ian,

Just a small change to restore the loadDefaultHash functionality. Don't know if it was removed by accident or intentionally, so feel free to close the request if you do not plan to support it anymore.

Thanks!
