### PR TITLE
#JQ00000338 Fix a bug,when startwith #divid/value

### DIFF
--- a/ui/src/jq.ui.js
+++ b/ui/src/jq.ui.js
@@ -1243,6 +1243,15 @@
                     //activeDiv = firstDiv;
                     if (defaultHash.length > 0 && that.loadDefaultHash&&defaultHash!=("#"+that.firstDiv.id)&&$(defaultHash).length>0)
                     {
+                        //Fix a bug,when startwith #divid/value, "that.activeDiv=$(defaultHash).get();" will be error 
+                        var slashIndex = defaultHash.indexOf('/');
+                        var hashLink = "";
+                        if (slashIndex != -1) {
+                            // Ignore everything after the slash for loading
+                            hashLink = defaultHash.substr(slashIndex);
+                            defaultHash = defaultHash.substr(0, slashIndex);
+                        }
+
                         that.activeDiv=$(defaultHash).get();
                         jq("#header #backButton").css("visibility","visible");
                         that.setBackButtonText(that.activeDiv.title)


### PR DESCRIPTION
1. error message:
   "Uncaught TypeError: Cannot read property 'title' of undefined "
2. Line numbers of offending code
   "that.activeDiv=$(defaultHash).get();"  (jq.ui.js:2597)
3. Test cases
   start with
   http://jqmobi.com/testdrive/#main/123
4. Description of the Error
   because the "defaultHash" = "#main/123"
   so  $(defaultHash).get() will return null
5. Browser/Device you are testing on
   chome

"that.activeDiv=$(defaultHash).get();" will be error
