### PR TITLE
Typo in customClickHandler. customClickHandler use evt.preventDefault and for this it needs a HTMLElement and not href.

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -2944,7 +2944,7 @@
         
         
             var custom=(typeof jq.ui.customClickHandler=="function")?jq.ui.customClickHandler:false;
-            if(custom!==false&&jq.ui.customClickHandler(theTarget.href)){
+            if(custom!==false&&jq.ui.customClickHandler(theTarget)){
                return true;
             }
             if (theTarget.href.toLowerCase().indexOf("javascript:") !== -1 || theTarget.getAttribute("data-ignore")) {


### PR DESCRIPTION
... and not the href. Seems to be a typo, otherwise please update the documentation, there you use preventDefault for customClickHandler.
