### PR TITLE
Fix bug when toggling the navigation bar on webkit

### DIFF
--- a/kitchensink/jq.ui.frosty.css
+++ b/kitchensink/jq.ui.frosty.css
@@ -767,6 +767,7 @@ select[disabled]~div { opacity:.7; }
 		position:absolute !important;
 		left:256px !important;
         -webkit-transition: all 0ms !important;
+        -webkit-transform:translate3d(0,0,0);
 	}
 	#badgephone{ display:none !important; }
 	#badgetablet{ display:inline-block !important; }


### PR DESCRIPTION
If we try to toggle the navigation bar using the frosty theme with chrome/webkit, the whole panel is moved to the right of the screen incorrectly. This is fixed in the default theme using this line.
