### PR TITLE
customClickHandler fix for jqMVC

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -4478,8 +4478,10 @@ if (!HTMLElement.prototype.unwatch) {
 		if (theTarget.tagName!=="undefined"&&theTarget.tagName.toLowerCase() == "a") {
 
             var custom=(typeof jq.ui.customClickHandler=="function")?jq.ui.customClickHandler:false;
-            if(custom!==false&&jq.ui.customClickHandler(theTarget)){
-               return true;
+            if(custom!==false){
+                e.preventDefault();
+                jq.ui.customClickHandler($(theTarget).attr("href"));
+                return;
             }
 
             if (theTarget.href.toLowerCase().indexOf("javascript:") !== -1||theTarget.getAttribute("data-ignore")) {

--- a/ui/src/jq.ui.js
+++ b/ui/src/jq.ui.js
@@ -1622,8 +1622,10 @@
 		if (theTarget.tagName!=="undefined"&&theTarget.tagName.toLowerCase() == "a") {
 
             var custom=(typeof jq.ui.customClickHandler=="function")?jq.ui.customClickHandler:false;
-            if(custom!==false&&jq.ui.customClickHandler(theTarget)){
-               return true;
+            if(custom!==false){
+                e.preventDefault();
+                jq.ui.customClickHandler($(theTarget).attr("href"));
+                return;
             }
 
             if (theTarget.href.toLowerCase().indexOf("javascript:") !== -1||theTarget.getAttribute("data-ignore")) {


### PR DESCRIPTION
This patch fixes the click routing for jqMVC which needs e.preventDefault(). Otherwise the default click handler will leave the page.

$(theTarget).attr("href") passes only "/route" instead of "http://www.example.com/route".
