### PR TITLE
Fixed an issue when loading ajax content a second time fails because of undefined anchor

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -4002,6 +4002,7 @@ if (!HTMLElement.prototype.unwatch) {
             that.hideMask();
             var loadAjax = true;
 
+            anchor = anchor || document.createElement("a"); //Hack to allow passing in no anchor
             if(target.indexOf("#") == -1) {
                 var urlHash = "url" + crc32(target); //Ajax urls
                 var crcCheck = jq("div.panel[data-crc='" + urlHash + "']");
@@ -4020,7 +4021,6 @@ if (!HTMLElement.prototype.unwatch) {
                 }
             }
             if(target.indexOf("#") == -1 && loadAjax) {
-                anchor = anchor || document.createElement("a"); //Hack to allow passing in no anchor
                 this.loadAjax(target, newTab, back, transition, anchor);
             } else {
                 this.loadDiv(target, newTab, back, transition);


### PR DESCRIPTION
if the content being loaded is ajax and it was loaded in the past (already existed), then the anchor is needed but its undefined in most cases).
This seems to be a larger problem as the anchor is required to load ajax content. There was already a fix for this for when the content was loaded for the first time but because of how the logic flow of the function went that code only was run the first time. My fixed move the creation of the fake anchor higher up in the code to encompass both cases (first load and repeated load)
