### PR TITLE
Fixing issue with popups. Redone version of pull request 162

### DIFF
--- a/plugins/jq.popup.js
+++ b/plugins/jq.popup.js
@@ -59,7 +59,7 @@
                 this.cancelClass = opts.cancelClass || "button";
                 this.doneText = opts.doneText || "Done";
                 this.doneCallback = opts.doneCallback || function(self) {
-                	self.hide();
+                    // no action by default
                 };
                 this.doneClass = opts.doneClass || "button";
                 this.cancelOnly = opts.cancelOnly || false;


### PR DESCRIPTION
Simplest reproduction:

```
$('body').popup({
});
```

This caused the error message:

Uncaught TypeError: Cannot call method 'unbind' of undefined jq.ui.js:1717
This is because the default doneCallback did a "self.hide()" at line 1692, which is also set if "autoCloseDone" is set (see line 1752).

It works fine if you use:

```
$('body').popup({
    doneCallback: function() {}
});
```

My fix is to remove the self.hide call at line 1692. You might have a better fix, or I may be missing something!
