### PR TITLE
Fake select inputs to go alongside the element that they map to

### DIFF
--- a/plugins/jq.selectBox.js
+++ b/plugins/jq.selectBox.js
@@ -56,7 +56,7 @@
                     fakeInput.onclick = function(e) {
                         that.initDropDown(this.linkId);
                     };
-                    theSel.parentNode.appendChild(fakeInput);
+                    $(fakeInput).insertBefore($(theSel));
                     //theSel.parentNode.style.position = "relative";
                     theSel.style.display = "none";
                     theSel.style.webkitAppearance = "none";


### PR DESCRIPTION
Inserting the fake select at the end of the parent input works but it's a bit easier if it's popped in next to the select element it refers to

Redone version of https://github.com/appMobi/jQ.Mobi/pull/163 to just edit the plugin and not the entire jq.ui.js file
