### PR TITLE
Fix issue with jQ.UI, JQMVC and Cordova

### DIFF
--- a/ui/src/jq.ui.js
+++ b/ui/src/jq.ui.js
@@ -1712,6 +1712,15 @@
                 }
                 return;
             }
+        
+            // file:/// fixes - this allows it to run on platforms like Cordova
+            // that pass file:/// at the start of hyperlinks
+            if (theTarget.href.indexOf("file:") === 0) {
+                var linkToUse = theTarget.href.replace('file:///android_asset/www/', '');
+                if(jq.ui.customClickHandler(linkToUse)) {
+                   return e.preventDefault();
+                }
+            }
 
             /* IE 10 fixes*/
 


### PR DESCRIPTION
On a jqMobi/jQ.UI/jQMVC project, my app worked fine in browser, but when I came to use Cordova to package it, my links to jQMVC controllers like Site/list threw "Chromium error -6" when I tested as an APK on my Nexus 7. I got the same errors under Trigger.IO.

I did some debugging and the file:/// links that Cordova used did not work with jQ.UI. This patch resolves that.

If you have a more elegant solution, I'm all ears!
