### PR TITLE
Fix: Disable orange highlight around links in Android 4.0.x

### DIFF
--- a/kitchensink/jq.ui.less
+++ b/kitchensink/jq.ui.less
@@ -45,7 +45,7 @@ body {
 
 * {
 	-webkit-user-select: none; /* Prevent copy paste for all elements except text fields */
-	-webkit-tap-highlight-color: rgba(255,255,255,0.5); /* Set highlight color for user interaction */
+	-webkit-tap-highlight-color: rgba(0,0,0,0); /* Set highlight color for user interaction */
 	-webkit-touch-callout: none; /* prevent the popup menu on any links*/
 	-webkit-box-sizing: border-box;
 	margin: 0;


### PR DESCRIPTION
Same configuration as Jquery Mobile project, works fine. (i had only this issue on Android 4.0.X)
