### PR TITLE
Prevent conflicting use of $ with jQuery

### DIFF
--- a/ui/jq.ui.js
+++ b/ui/jq.ui.js
@@ -2459,7 +2459,7 @@ if (!HTMLElement.prototype.unwatch) {
 //Other
 //orientationchange-reshape - resize event due to an orientationchange action
 //reshape - window.resize/window.scroll event (ignores onfocus "shaking") - general reshape notice
-(function() {
+(function($) {
 
 	//singleton
 	$.touchLayer = function(el) {
@@ -3065,7 +3065,7 @@ if (!HTMLElement.prototype.unwatch) {
 		}
 	};
 
-})();
+})(jq);
  /**
  * jq.ui - A User Interface library for creating jqMobi applications
  *
@@ -4842,7 +4842,7 @@ if (!HTMLElement.prototype.unwatch) {
 
 //The following functions are utilitiy functions for jqUi within appMobi.
 
-(function() {
+(function($) {
     $(document).one("appMobi.device.ready", function() { //in AppMobi, we need to undo the height stuff since it causes issues.
         setTimeout(function() {
             document.getElementById('jQUi').style.height = "100%";
@@ -4853,7 +4853,7 @@ if (!HTMLElement.prototype.unwatch) {
             $.ui.blockPageScroll();
         })
     });
-})();
+})(jq);
 (function($ui){
     
         function fadeTransition (oldDiv, currDiv, back) {
@@ -4919,7 +4919,7 @@ if (!HTMLElement.prototype.unwatch) {
             }
         }
         $ui.availableTransitions.fade = fadeTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
     
         function flipTransition (oldDiv, currDiv, back) {
@@ -5003,7 +5003,7 @@ if (!HTMLElement.prototype.unwatch) {
             }
         }
         $ui.availableTransitions.flip = flipTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
         
          function popTransition(oldDiv, currDiv, back) {
@@ -5073,7 +5073,7 @@ if (!HTMLElement.prototype.unwatch) {
             }
         }
         $ui.availableTransitions.pop = popTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
     
         /**
@@ -5131,7 +5131,7 @@ if (!HTMLElement.prototype.unwatch) {
         }
         $ui.availableTransitions.slide = slideTransition;
         $ui.availableTransitions['default'] = slideTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
     
         function slideDownTransition (oldDiv, currDiv, back) {
@@ -5197,7 +5197,7 @@ if (!HTMLElement.prototype.unwatch) {
             }
         }
         $ui.availableTransitions.down = slideDownTransition;
-})($.ui);
+})(jq.ui);
 
 (function($ui){
     
@@ -5254,5 +5254,5 @@ if (!HTMLElement.prototype.unwatch) {
             }
         }
         $ui.availableTransitions.up = slideUpTransition;
-})($.ui);
+})(jq.ui);
 

--- a/ui/src/jq.ui.js
+++ b/ui/src/jq.ui.js
@@ -1774,7 +1774,7 @@
 
 //The following functions are utilitiy functions for jqUi within appMobi.
 
-(function() {
+(function($) {
     $(document).one("appMobi.device.ready", function() { //in AppMobi, we need to undo the height stuff since it causes issues.
         setTimeout(function() {
             document.getElementById('jQUi').style.height = "100%";
@@ -1785,4 +1785,4 @@
             $.ui.blockPageScroll();
         })
     });
-})();
+})(jq);

--- a/ui/transitions/all.js
+++ b/ui/transitions/all.js
@@ -63,7 +63,7 @@
             }
         }
         $ui.availableTransitions.fade = fadeTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
     
         function flipTransition (oldDiv, currDiv, back) {
@@ -147,7 +147,7 @@
             }
         }
         $ui.availableTransitions.flip = flipTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
         
          function popTransition(oldDiv, currDiv, back) {
@@ -217,7 +217,7 @@
             }
         }
         $ui.availableTransitions.pop = popTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
     
         /**
@@ -275,7 +275,7 @@
         }
         $ui.availableTransitions.slide = slideTransition;
         $ui.availableTransitions['default'] = slideTransition;
-})($.ui);
+})(jq.ui);
 (function($ui){
     
         function slideDownTransition (oldDiv, currDiv, back) {
@@ -341,7 +341,7 @@
             }
         }
         $ui.availableTransitions.down = slideDownTransition;
-})($.ui);
+})(jq.ui);
 
 (function($ui){
     
@@ -398,4 +398,4 @@
             }
         }
         $ui.availableTransitions.up = slideUpTransition;
-})($.ui);
+})(jq.ui);

--- a/ui/transitions/fade.js
+++ b/ui/transitions/fade.js
@@ -63,4 +63,4 @@
             }
         }
         $ui.availableTransitions.fade = fadeTransition;
-})($.ui);
+})(jq.ui);

--- a/ui/transitions/flip.js
+++ b/ui/transitions/flip.js
@@ -81,4 +81,4 @@
             }
         }
         $ui.availableTransitions.flip = flipTransition;
-})($.ui);
+})(jq.ui);

--- a/ui/transitions/pop.js
+++ b/ui/transitions/pop.js
@@ -67,4 +67,4 @@
             }
         }
         $ui.availableTransitions.pop = popTransition;
-})($.ui);
+})(jq.ui);

--- a/ui/transitions/slide.js
+++ b/ui/transitions/slide.js
@@ -56,4 +56,4 @@
         }
         $ui.availableTransitions.slide = slideTransition;
         $ui.availableTransitions['default'] = slideTransition;
-})($.ui);
+})(jq.ui);

--- a/ui/transitions/slideDown.js
+++ b/ui/transitions/slideDown.js
@@ -63,4 +63,4 @@
             }
         }
         $ui.availableTransitions.down = slideDownTransition;
-})($.ui);
+})(jq.ui);

--- a/ui/transitions/slideUp.js
+++ b/ui/transitions/slideUp.js
@@ -54,4 +54,4 @@
             }
         }
         $ui.availableTransitions.up = slideUpTransition;
-})($.ui);
+})(jq.ui);


### PR DESCRIPTION
Some files expect $ to be jq, but if jquery is loaded before jq the $ is taken by jquery, causing all kinds of errors. This commit fixes this.
