### PR TITLE
Fixed callback not fired on slidein toggle

### DIFF
--- a/plugins/jq.fx.js
+++ b/plugins/jq.fx.js
@@ -65,9 +65,9 @@
        $('.tool_tip').slideToggle('300ms');
        ```
      *
-     * @param {String} animation time
-     * @param {Function} [callback]
-     * @param {String} css3 easing method
+     * @param {String} duration animation time (e.g. "100ms")
+     * @param {Function} callback [callback]
+     * @param {String} easing css3 easing method
      * @title $().slideToggle(time,callback,easing);
      */
     $.fn.slideToggle = function (duration, callback, easing) {
@@ -75,12 +75,13 @@
             time: duration ? duration : "500ms",
             callback: callback ? callback : null,
             easing: easing ? easing : "linear"
-        }
+        };
+		
         for (var i = 0; i < this.length; i++) {
             var hideshow = this.css("display", null, this[i]);
             var expand = false;
             var elem = $(this[i]);
-            if (hideshow == "none") {
+            if (hideshow === "none") {
                 elem.show();
                 expand = true;
             }
@@ -90,15 +91,16 @@
                 opts['height'] = height;
             } else {
                 opts['height'] = "0px";
-                var oldCB = callback;
+                var originalCallback = callback;
                 callback = function () {
                     elem.hide();
                     var cbOpts = {
+						callback: originalCallback,
                         height: height,
                         time: "0ms"
-                    }
+                    };
                     elem.css3Animate(cbOpts);
-                }
+                };
             }
             if (callback) opts['callback'] = callback;
             window.setTimeout(function () {
@@ -106,5 +108,5 @@
             }, 1);
         }
         return this;
-    }
+    };
 })(jq);


### PR DESCRIPTION
Was trying to understand fx options and looked at the slideToggle-function - there i saw the original callback being stored in a variable which was never used (well, netbeans saw it for me and was so kind to notify me :grinning: ).

Trying out the function i saw my test callback only being executed every second time - bam! Works now on every toggle as one would expect, hope this change makes sense repectively follows the authors intention.
