### PR TITLE
fixes null exception in nativeScroller

### DIFF
--- a/plugins/jq.scroller.js
+++ b/plugins/jq.scroller.js
@@ -499,7 +499,7 @@
 			var triggered = this.el.scrollTop <= -(this.refreshHeight);
 
 			this.fireRefreshRelease(triggered, true);
-            if(triggered){
+            if(triggered && this.refreshContainer){
                 //lock in place
                 this.refreshContainer.style.position="relative";
                 this.refreshContainer.style.top="0px";


### PR DESCRIPTION
If pullToRefresh isn't used and the user pulls to fast downwards, you'll get a null exception, because this.refreshContainer is null. IMHO there shouldn't be a side effect of this patch.
