### PR TITLE
Panel div with data-footer="none" causes an error

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -4190,6 +4190,7 @@
             //$asap removed since animations are fixed in css3animate
             if (hasFooter && hasFooter.toLowerCase() == "none") {
                 that.toggleNavMenu(false);
+                hasFooter = false;
             } else {
                 that.toggleNavMenu(true);
             }

--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -1068,6 +1068,7 @@
             //$asap removed since animations are fixed in css3animate
             if (hasFooter && hasFooter.toLowerCase() == "none") {
                 that.toggleNavMenu(false);
+                hasFooter = false;
             } else {
                 that.toggleNavMenu(true);
             }


### PR DESCRIPTION
A panel-div with data-footer="none" causes an error "Uncaught TypeError: Cannot read property 'childNodes' of undefined appframework.ui.js:3774" in ui.updateNavbarElements(). This function tries to copy navigation elements with id=none, which do not exist. Probably ui.updateNavbarElements() does not even need to be called, so I added "hasFooter = false;" in ui.parsePanelFunctions().
