### PR TITLE
fixed TypeError: Unable to access callee of strict mode function

### DIFF
--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -5,7 +5,6 @@
  * @author AppMobi
  * @version 2.0
  */ (function($) {
-    "use strict";
 
     var hasLaunched = false;
     var startPath = window.location.pathname;


### PR DESCRIPTION
arguments.callee is used in function checkNodeInserted()

I've got this TypeError because "use strict" doesn't allow arguments.callee anymore. unfortunately.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode
»[…] Third, arguments.callee is no longer supported. […]«
