### PR TITLE
fix for "assign to readonly property line 2055"

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -2540,9 +2540,11 @@ if (!window.af || typeof(af) !== "function") {
             if (!node) return;
             //cleanup children
             var children = node.childNodes;
-            if (children && children.length > 0)
-                for (var child in children)
-                    cleanUpContent(children[child], kill);
+            if (children && children.length > 0) {
+                for (var i; i < children.length; i++) {
+                    cleanUpContent(children[i], kill);
+                }
+            }
 
             cleanUpNode(node, kill);
         }


### PR DESCRIPTION
Hi Ian,

I've got a little nasty bug on iOS devices »assign to readonly property line 2055«. I'll tracked it down to the in-loop. It will loop to the length property and then call cleanUpContent() with the value 1 (number). This will be passed to afmid(element) where then »(element._afmid = _afmid++)« will be called. This will results in the assign to readonly exception.
