### PR TITLE
FeatureRequest: property to disable auto-pressed feature completely

### DIFF
--- a/plugins/af.touchEvents.js
+++ b/plugins/af.touchEvents.js
@@ -40,9 +40,9 @@
                 touch.isDoubleTap = true;
             touch.last = now;
            longTapTimer=setTimeout(longTap, longTapDelay);
-            if (!touch.el.data("ignore-pressed"))
+            if ($.ui.useAutoPressed && !touch.el.data("ignore-pressed"))
                 touch.el.addClass("pressed");
-            if(prevEl&&!prevEl.data("ignore-pressed"))
+            if(prevEl && $.ui.useAutoPressed && !prevEl.data("ignore-pressed"))
                 prevEl.removeClass("pressed");
             prevEl=touch.el;
         }).bind('touchmove', function(e) {
@@ -56,7 +56,7 @@
                 e=e.originalEvent;
             if (!touch.el)
                 return;
-            if (!touch.el.data("ignore-pressed"))
+            if ($.ui.useAutoPressed && !touch.el.data("ignore-pressed"))
                 touch.el.removeClass("pressed");
             if (touch.isDoubleTap) {
                 touch.el.trigger('doubleTap');
@@ -78,7 +78,7 @@
                 }, 250);
             }
         }).bind('touchcancel', function() {
-            if(touch.el&& !touch.el.data("ignore-pressed"))
+            if(touch.el && $.ui.useAutoPressed && !touch.el.data("ignore-pressed"))
                 touch.el.removeClass("pressed");
             touch = {};
             clearTimeout(longTapTimer);

--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -146,6 +146,7 @@
         useOSThemes: true,
         lockPageBounce: false,
         animateHeaders: true,
+        useAutoPressed: true,
         autoBoot: function() {
             this.hasLaunched = true;
             if (this.autoLaunch) {


### PR DESCRIPTION
Hi Ian,

I've send you this feature request (pr) to disable the automatic »pressed« class in touchEvents. I create a setting »$.ui.useAutoPressed« which is set to true by default – like in af. But you could set it to false, to prevent the »pressed« class on touch events.

We've got 2 probs with the existing »AutoPressed« feature:
1. our designers don't like the pressed class applied to every touched element (they prefer a pressed class only on »touchable« elements.
2. this feature collidates with CanvasJS and generates: »Maximum call stack size exceeded / appframework.js line 913« (on desktop safari with simulated touch events)

I hope you'll like this request. Best regards dom
