### PR TITLE
fixed $.ui.scrollingDivs to object literal

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -3283,7 +3283,7 @@
         selectBox: $.selectBox ? $.selectBox : false,
         ajaxUrl: "",
         transitionType: "slide",
-        scrollingDivs: [],
+        scrollingDivs: {},
         firstDiv: "",
         hasLaunched: false,
         launchCompleted: false,


### PR DESCRIPTION
this attribute is used as object but was initialized as array literal
