### PR TITLE
fixes "undefined is not an object" exception in af.ui on "exit-edit-resh...

### DIFF
--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -1553,7 +1553,9 @@
             });
             if ($.os.ios) {
                 $.bind($.touchLayer, 'exit-edit-reshape', function() {
-                    that.scrollingDivs[that.activeDiv.id].setPaddings(0, 0);
+                    if (that.activeDiv && that.activeDiv.id && that.scrollingDivs.hasOwnProperty(that.activeDiv.id)) {
+                        that.scrollingDivs[that.activeDiv.id].setPaddings(0, 0);
+                    }
                 });
             }
 


### PR DESCRIPTION
We've got the exception "undefined is not an object in appframework.ui.js:4702" on orientationchange (ios6) with an open modal panel, which has a form and input field. After this small fix everything seems fine
