### PR TITLE
fixed $.ui.scrollingDivs to object literal (second try)

### DIFF
--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -136,7 +136,7 @@
         selectBox: $.selectBox ? $.selectBox : false,
         ajaxUrl: "",
         transitionType: "slide",
-        scrollingDivs: [],
+        scrollingDivs: {},
         firstDiv: "",
         hasLaunched: false,
         launchCompleted: false,


### PR DESCRIPTION
This time I fixed the source file, not the composed file. Sorry, my fault: the first patch (3f08645ddfbcb42fe38aed3d97c821b10158e7bb) was in the wrong file.
