### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "intel-appframework",
+  "homepage": "http://app-framework-software.intel.com/",
+  "description": "The definitive HTML5 mobile javascript framework",
+  "version": "2.0.0",
+  "keywords": [
+    "mobile", "app", "html5", "hybrid", "cordova", "phonegap", "tablet", "touch"
+  ],
+  "repository": {
+    "type": "git",
+    "url" : "git@github.com:01org/appframework.git"
+  },
+  "main": "appframework.min.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Add Bower configuration so that bower-require can autoload the App framework

See https://github.com/01org/appframework/issues/236 for a discussion of this.

Please note that tags will have to be created following [semver](http://semver.org/) so 2.0.0 should be created (rather than 2.0).
