### PR TITLE
fixed 'null' is not an object in .../ui/appframework.ui.js, line 3015

### DIFF
--- a/plugins/af.touchLayer.js
+++ b/plugins/af.touchLayer.js
@@ -523,7 +523,8 @@
         //scroll finish detectors
         scrollEnded: function(e) {
             //this.log("scrollEnded");
-            if (e  && this.scrollTimeoutEl_) this.scrollTimeoutEl_.removeEventListener('scroll', this.scrollEndedProxy_, false);
+            if (this.scrollTimeoutEl_ === null) { return; }
+            if (e) this.scrollTimeoutEl_.removeEventListener('scroll', this.scrollEndedProxy_, false);
             this.fireEvent('UIEvents', 'scrollend', this.scrollTimeoutEl_, false, false);
             this.scrollTimeoutEl_ = null;
         },


### PR DESCRIPTION
in af.touchlayer.js

Hi Ian,

I've got this exception on an iPhone 5 with iOS 6.1.4 while testing my dialogs. It appears (sometimes/often) if a select box got focus, the wheel-picker appeared and the screen was scrolled.

This patch seems to prevent this, but I'm not sure if it isn't better to just return if this.scrollTimeoutEl_ is null. What do you think Ian?
