### PR TITLE
fixes that $.trigger call all bound event handler

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -2477,7 +2477,7 @@ if (!window.af || typeof(af) !== "function") {
             if (!$.isArray(args)) args = [];
             for (var i = 0; i < ev.length; i++) {
                 if (obj.__events[ev[i]]) {
-                    var evts = obj.__events[ev[i]];
+                    var evts = obj.__events[ev[i]].slice(0);
                     for (var j = 0; j < evts.length; j++)
                         if ($.isFunction(evts[j]) && evts[j].apply(obj, args) === false)
                             ret = false;


### PR DESCRIPTION
even, if they or some of them use $.unbind() to unbind themselves

I've wondered today why not all of my "content-loaded" event handler were called. And after I've bound additional (test) functions, my function was called.

These function(s) should always only run once after they're called, so they unbind themselves with:
$.unbind($.ui, "content-loaded", _myFunction)

But this brakes the loop over the referenced event array, because it's length got reduced, and some handler won't be reached. Sometimes they're called on the next event, or later which causes really strange effects.

The fix creates a copy of the event array which doesn't change on $.unbind() so all event handler are called.

I'll hope you'll like it.

Best regards
dom
