### PR TITLE
Fix issue with dropdown boxes

### DIFF
--- a/plugins/af.selectBox.js
+++ b/plugins/af.selectBox.js
@@ -102,7 +102,7 @@
                     var scrollThreshold = numOnly($list.find("li").computedStyle("height"));
                     var theHeight = numOnly($("#afSelectBoxContainer").computedStyle("height"));
                     if (foundInd * scrollThreshold >= theHeight) scrollToPos = (foundInd - 1) * -scrollThreshold;
-                    this.scroller.scrollTo({
+                    this.scroller._scrollTo({
                         x: 0,
                         y: scrollToPos
                     });
@@ -129,7 +129,7 @@
                 el.selectedIndex = value;
                 $el.find("option").prop("selected", false);
                 $el.find("option:nth-child(" + (value + 1) + ")").prop("selected", true);
-                this.scroller.scrollTo({
+                this.scroller._scrollTo({
                     x: 0,
                     y: 0
                 });


### PR DESCRIPTION
scroller.scrollTo is not a function. scroller._scrollTo works.
Without this patch, I was getting:

```
error init dropdownTypeError: Object #<Object> has no method 'scrollTo' appframework.ui.js
```

Framework will need recompiling if this makes it into master
