### PR TITLE
Two variables with their `.toString()` equal may not be the same value.

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -2099,7 +2099,7 @@ if (!window.af || typeof(af) !== "function") {
             if (event.ns)
                 var matcher = matcherFor(event.ns);
             return (handlers[afmid(element)] || []).filter(function(handler) {
-                return handler && (!event.e || handler.e == event.e) && (!event.ns || matcher.test(handler.ns)) && (!fn || handler.fn == fn || (typeof handler.fn === 'function' && typeof fn === 'function' && "" + handler.fn === "" + fn)) && (!selector || handler.sel == selector);
+                return handler && (!event.e || handler.e == event.e) && (!event.ns || matcher.test(handler.ns)) && (!fn || handler.fn == fn || (typeof handler.fn === 'function' && typeof fn === 'function' && handler.fn === fn)) && (!selector || handler.sel == selector);
             });
         }
         /**


### PR DESCRIPTION
```
function proxy(fn) {
    return function () {
        fn();
    }
};
var a = proxy(function () {
    alert('a');
});
var b = proxy(function () {
    alert('b');
});
var $body = $(document.body);
$body.on('click', a).on('click', b);
// Both listener will work.
$body.off('click', a);
// Both listener will be mistakenly removed.
```
