### PR TITLE
$.each with afm object counts length prop as value.

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -306,7 +306,7 @@ if (!window.af || typeof(af) !== "function") {
                         return elements;
             } else if ($.isObject(elements))
                 for (key in elements) {
-                    if (!elements.hasOwnProperty(key))
+                    if (!elements.hasOwnProperty(key) || key == "length")
                         continue;
                     if (callback(key, elements[key]) === false)
                         return elements;


### PR DESCRIPTION
When use $.each with afm object, each loop counts one more value, this value is the length of the object.

Checking key == "length" the problem is solved.
