### PR TITLE
add bounced back for slidemenu when slide not enough ( Misoperation )

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -4,7 +4,7 @@
  *
  */;
 (function($) {
-    var startX, startY, blocking = false,
+    var startX, startY, dx, dy, blocking = false,
         checking = false,
         doMenu = true,
         showHide = false;
@@ -18,6 +18,7 @@
         var elems = $("#content, #header, #navbar");
         var $menu = $("#menu");
         var max = $("#menu").width();
+        var slideOver = max/3;
         var menuState;
         var transTime = $.ui.transitionTime;
 
@@ -52,10 +53,10 @@
                 doMenu=true;
              if(!doMenu) return;
 
-            var dx = e.touches[0].pageX;
-            var dy = e.touches[0].pageY;
-            //if (!menuState && dx < startX) return;
-            //else if (menuState && dx > startX) return;
+            dx = e.touches[0].pageX;
+            dy = e.touches[0].pageY;
+            if (!menuState && dx < startX) return;
+            else if (menuState && dx > startX) return;
             if (Math.abs(dy - startY) > Math.abs(dx - startX)) {
                 doMenu = false;
                 return true;
@@ -76,6 +77,10 @@
             elems.cssTranslate(thePlace + "px,0");
             e.preventDefault();
             e.stopPropagation();
+            
+            if( Math.abs(dx-startX) < slideOver){
+                showHide = showHide ? false : 2;
+            }
 
         });
         $("#afui").bind("touchend", function(e) {


### PR DESCRIPTION
![2013-9-7 16-14-46](https://f.cloud.github.com/assets/4945292/1100911/1d8496a2-1797-11e3-9f00-3069a3c0bf43.jpg)
add bounced back for slidemenu when slide not enough 
now must slide over 1/3width to open or close slidemenu

1.修复同一方向划动出现关闭slidemenu的问题
2.增加划动不足三分之一侧栏宽度时回弹的效果,避免误操作(平常轻轻一碰侧栏就开了)
