### PR TITLE
Fixed $.ui.showBackButton property

### DIFF
--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -334,6 +334,7 @@
            $.ui.showBackButton = false; //
          * @title $.ui.showBackButton
          */
+        showBackbutton: true, // Kept for backward compatibility.
         showBackButton: true,
         /**
          *  Override the back button text
@@ -1403,7 +1404,7 @@
                 this.setBackButtonVisibility(false);
                 this.history = [];
                 $("#header #menubadge").css("float", "left");
-            } else if (this.showBackButton) this.setBackButtonVisibility(true);
+            } else if (this.showBackButton && this.showBackbutton) this.setBackButtonVisibility(true);
             this.activeDiv = what;
             if (this.scrollingDivs[this.activeDiv.id]) {
                 this.scrollingDivs[this.activeDiv.id].enable(this.resetScrollers);


### PR DESCRIPTION
I propose to change the property showBackbutton to showBackButton for the following reasons:
- It would be logical to name this property showBackButton as all other properties are using camelCase.
- Documentation at [showBackButton](http://app-framework-software.intel.com/api2/index.html#$_ui_showBackButton) is using the camelCase version.
