### PR TITLE
Add flexbox button groups (.button-grouped.flex)

### DIFF
--- a/css/src/buttons.css
+++ b/css/src/buttons.css
@@ -86,6 +86,28 @@
 	border-bottom-right-radius: 6px;
 }
 
+#afui .button-grouped.flex {
+	display: -webkit-flex;
+	display: -moz-flex;
+	display: -ms-flexbox;
+	display: flex;
+}
+
+#afui .button-grouped.flex > .button {
+	-webkit-flex: 1 auto;
+	-moz-flex: 1 auto;
+	-ms-flex: 1 auto;
+	flex: 1 auto;
+
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+#afui .button-grouped.flex.vertical {
+	display: inline-block;
+}
+
 #afui .button-grouped.vertical * {
 	border-radius:0px;
 	display:block;

--- a/index.html
+++ b/index.html
@@ -1244,7 +1244,15 @@ The parent id for this div is "content". Let's verify it.
                         <a class="button icon pencil">Test</a>
                         <a class="button">Test</a>
                         <a class="button">Test</a>
-                    </div><br>
+                    </div>
+                    <br><br>
+                    Grouped flexbox<br><br>
+                    <div class="button-grouped flex">
+                        <a class="button icon cloud">App Framework Button Groups</a>
+                        <a class="button">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</a>
+                        <a class="button">Test</a>
+                    </div>
+                    <br><br>
                     Colors<br><br>
                     <a class="button yellow">Yellow</a><br><br>
                     <a class="button red">Red</a><br><br>


### PR DESCRIPTION
Flexbox button groups (`.vertical` layout takes precedence):

``` HTML
<div class='button-grouped flex'>
  <a class='button'>A</a>
  <a class='button'>B</a>
  <a class='button'>C</a>
</div>
```

I also updated the Kitchen Sink `#uibuttons` example.
