### PR TITLE
fixed sticky slidemenu

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -57,12 +57,10 @@
             dy = e.touches[0].pageY;
             if (!menuState && dx < startX) return;
             else if (menuState && dx > startX) return;
-            if (Math.abs(dy - startY) > Math.abs(dx - startX)) {
-                doMenu = false;
-                return true;
-            }            
+            if (Math.abs(dy - startY) > Math.abs(dx - startX)) return true;
             
-            if (dx > max) return true;
+            if (dx-startX > max) return true;
+            if (startX-dx > max) return true;
             
             showHide = dx - startX > 0 ? 2 : false;
             var thePlace = Math.abs(dx - startX);


### PR DESCRIPTION
1. Issue: 

two issues with slide menu: 
- when swiping to reveal side menu, it some times gets stuck in between, does not close completely or open completely. 
- another issue is that swipe only works when it is started within the left 256px of the panel (width of side menu)
1. Test case:

open the af kitchensink app, and swipe right to open sidemenu and swipe down at the same time, notice that it gets stuck in between.

also u cannot start swipe from the rightside of the panel, swipe can only be started within the left 256px of panel.
1. Fix description:
- this fixes the sticky issue:
  removed "doMenu = false" in "if (Math.abs(dy - startY) > Math.abs(dx - startX))" -> this was leaving the panel stuck in between, without this it will snap to either open or close. 
- this fixes the slide start position, so now u can slide anywhere on panel to reveal the side menu:
  removed "if (dx > max) return true;" -> this was only allowing panel swipe starting within the first 256px (width of sidemenu).
  if (dx-startX > max) return true; -> will make sure that panel will not slide out more that the width of side menu
  if (startX-dx > max) return true; -> will make sure that panel will not slide in more that the width of side menu
