### PR TITLE
fix for slidemenu Issue #447

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -21,6 +21,7 @@
         var slideOver = max/3;
         var menuState;
         var transTime = $.ui.transitionTime;
+        $.ui.toggleSideMenu(false, null, 0);
 
         window.addEventListener("resize", function(e) {
             max = $("#menu").width();


### PR DESCRIPTION
## Issue

On first time load, if you slide left when the side menu is already closed, it has a weird effect where the panel detaches from the right edge and slides. This happens only the first time after load.
## Test case

Issue can be reproduced with AF kitchen sink app, open app on phone form factor and try to swipe left, (i.e try to close side menu when it is already closed), notice that the panel detaches from the right edge and has a weird effect.
## Fix Description

The plugin blocks sliding wrong direction by checking if "#menu" display style is none, at start the "#menu" display is not none, so added `$.ui.toggleSideMenu(false, null, 0);` at plugin start so that the display is set to none for "#menu" at start. Fix has been tested on phone and tablet resolution where the side menu is always open.
