### PR TITLE
added light theme navbar text-shadow

### DIFF
--- a/css/src/win8.css
+++ b/css/src/win8.css
@@ -119,8 +119,11 @@
   background:inherit;
   -webkit-backface-visibility: hidden;
   -webkit-perspective: 1000;
-
 }
+#afui.win8.light #navbar a {
+  text-shadow: 0 -1px rgba(255, 255, 255, 0.5);  
+}
+
  #afui.win8 #navbar a.pressed {
   background-color: rgba(166, 166, 166, 0.7);
  }


### PR DESCRIPTION
## Issue

The win8 theme for navbar had black text-shadow, when switched to light theme it changed the text also to black, this made the navbar items with black text with black shadow. 
## Test Case

Open the kitchen sink app, change to win8 theme and then change to lighter theme. Notice that the nav bar items have black text/icon with black shadow, making it it look blurry
## Fix

added css for light navbar with white text-shadow
