### PR TITLE
allow sliding only if sidemenu is enabled

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -43,7 +43,7 @@
         });
         $("#afui").bind("touchmove", function(e) {
 
-            
+            if (!$.ui.isSideMenuEnabled()) return true;
             if (!$.ui.slideSideMenu||keepOpen) return true;
             if (!checking) {
                 checking = true;


### PR DESCRIPTION
## Issue

sliding was possible even if sidemenu is diabled
## Test Case

open index.html kitchensink, in console type $.ui.disablesidemenu(), and then try slide, notice that slide is possible and it reveals empty side menu
## Fix

added simple checker: `if (!$.ui.isSideMenuEnabled()) return true;`
