### PR TITLE
fix for issue #465

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -45,23 +45,21 @@
 
             if (!$.ui.isSideMenuEnabled()) return true;
             if (!$.ui.slideSideMenu||keepOpen) return true;
+            dx = e.touches[0].pageX;
+            dy = e.touches[0].pageY;
+            if (!menuState && dx < startX) return true;
+            if (menuState && dx > startX) return true;
+            if (dx-startX > max) return true;
+            if (startX-dx > max) return true;
+            if (Math.abs(dy - startY) > Math.abs(dx - startX)) return true;
+            
             if (!checking) {
                 checking = true;
                 doMenu=false;
                 return true;
-            }
-            else 
+            } else { 
                 doMenu=true;
-             if(!doMenu) return;
-
-            dx = e.touches[0].pageX;
-            dy = e.touches[0].pageY;
-            if (!menuState && dx < startX) return;
-            else if (menuState && dx > startX) return;
-            if (Math.abs(dy - startY) > Math.abs(dx - startX)) return true;
-            
-            if (dx-startX > max) return true;
-            if (startX-dx > max) return true;
+            }
             
             showHide = dx - startX > 0 ? 2 : false;
             var thePlace = Math.abs(dx - startX);


### PR DESCRIPTION
## Issue

issue described in #465
## Test case

clicking sidemenu button and scrolling was toggling sidemenu
## Fix

`if (Math.abs(dy - startY) > Math.abs(dx - startX)) return true` moved this check for scrolling before setting `doMenu=true;`. This will prevent sidemenu toggle while scrolling.
(No real change in code, just moved around the checkers)
