### PR TITLE
added border-right for sidemenu

### DIFF
--- a/css/src/android.css
+++ b/css/src/android.css
@@ -129,7 +129,7 @@
 }
 
 #afui.android > #menu {
-    border-right:none;
+    border-right:1px solid rgba(128,128,128,0.5);
 	color:inherit;
 	background:inherit;
 }

--- a/css/src/bb.css
+++ b/css/src/bb.css
@@ -139,7 +139,7 @@ color: white;
 }
 
 #afui.bb #menu {
-    border-right:none;
+    border-right:1px solid #bbb;
     background: #fff;
     color: #000;
 }

--- a/css/src/ios7.css
+++ b/css/src/ios7.css
@@ -57,9 +57,9 @@
 }
 
 #afui.ios7 > #menu {
-    border-right:none;
+    border-right:1px solid #bbb;
     background:rgba(238,238,238,255);
-     color:black;
+    color:black;
 }
 
 #afui.ios7 #menu .list li,#afui.ios7 #menu .list .divider,#afui.ios7 #menu .list li:first-child,#afui.ios7 #menu .list li:last-child {

--- a/css/src/win8.css
+++ b/css/src/win8.css
@@ -243,7 +243,7 @@
 }
 
 #afui.win8 > #menu {
-  border-right:none;
+    border-right:1px solid rgba(128,128,128,0.5);
 	color:inherit;
 	background:inherit;
 }


### PR DESCRIPTION
## Issue

Side menu does not have `border-right`, in tablet mode there is no visible separation between sidemenu and main panel, so added a 1px border similar to splitview in native UI
(Not sure why, #menu `border-right` for all themes were set to `none`, the default css does have a 1px `border-right`, if there was a specific reason for setting `none`, let me know and ignore this pull-request)
## Test Case

open ios7, android, bb and win8 themes of kitchensink in tablet mode, notice that there is no separator between sidemenu and main panel
## Fix

Add `border-right` for #menu for ios7, bb, win8, android themes
