### PR TITLE
panel scroll locking when side menu is open

### DIFF
--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -567,9 +567,10 @@
          * @param {Boolean} [force]
          * @param {Function} [callback] Callback function to execute after menu toggle is finished
          * @param {int} [time] Time to run the transition
-         * @title $.ui.toggleSideMenu([force],[callback],[time])
+         * @param {Boolean} [panelScrolling] Allow scrolling on main panel when side menu is open
+         * @title $.ui.toggleSideMenu([force],[callback],[time],[panelScrolling])
          */
-        toggleSideMenu: function(force, callback, time) {
+        toggleSideMenu: function(force, callback, time, panelScrolling) {
             if (!this.isSideMenuEnabled() || this.togglingSideMenu) return;
 
             var that = this;
@@ -588,9 +589,11 @@
                         that.togglingSideMenu = false;
                         els.vendorCss("Transition", "");
                         if (callback) callback(canceled);
+                        if(af().scroller && !panelScrolling) {
+                            $('.panel[selected="true"]').scroller().lock();
+                        } 
                     }
                 });
-
             } else if (force === undefined || (force !== undefined && force === false)) {
                 this.togglingSideMenu = true;
                 that.css3animate(els, {
@@ -603,6 +606,9 @@
                         that.togglingSideMenu = false;
                         if (callback) callback(canceled);
                         menu.hide();
+                        if(af().scroller && !panelScrolling) {
+                            $('.panel[selected="true"]').scroller().unlock();
+                        } 
                     }
                 });
             }


### PR DESCRIPTION
## Issue

See issue #468, main panel is scrollable when side menu is open, also when slidemenu plugin is used,scrolling is possible while sliding menu.
## Test Case
- Open kitchen sink app and toggle side menu, notice that main panel is scrollable.
- Swipe main panel to right and also move up/down, notice that main panel is scrollable
## Fix
- implemented main panel scroll lock/unlock when side menu is open/closed.
- used `$().scroller().lock()` and `$().scroller().unlock()` functions of scroller plugin when side menu is shown or hidden.
- added an option param for `$.ui.toggleSideMenu()` to disable scroll locking, by default if no option is specified then - panel scrolling is locked when side menu is open.
- this will first check if `af().scroller` plugin exists.
