### PR TITLE
fix a bug for jsonp request

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1649,8 +1649,17 @@ if (!window.af || typeof(af) !== "function") {
 
                 if (!('async' in settings) || settings.async !== false)
                     settings.async = true;
+                    
+                if ($.isObject(settings.data))
+                    settings.data = $.param(settings.data);
+                if (settings.type.toLowerCase() === "get" && settings.data) {
+                    if (settings.url.indexOf("?") === -1)
+                        settings.url += "?" + settings.data;
+                    else
+                        settings.url += "&" + settings.data;
+                }
 
-                if (!settings.dataType)
+		if (!settings.dataType)
                     settings.dataType = "text/html";
                 else {
                     switch (settings.dataType) {
@@ -1669,22 +1678,15 @@ if (!window.af || typeof(af) !== "function") {
                         case "text":
                             settings.dataType = 'text/plain';
                             break;
+                        case "jsonp":
+                            return $.jsonP(settings);
+                            break;
                         default:
                             settings.dataType = "text/html";
                             break;
-                        case "jsonp":
-                            return $.jsonP(opts);
                     }
                 }
-                if ($.isObject(settings.data))
-                    settings.data = $.param(settings.data);
-                if (settings.type.toLowerCase() === "get" && settings.data) {
-                    if (settings.url.indexOf("?") === -1)
-                        settings.url += "?" + settings.data;
-                    else
-                        settings.url += "&" + settings.data;
-                }
-
+                
                 if (/=\?/.test(settings.url)) {
                     return $.jsonP(settings);
                 }


### PR DESCRIPTION
### bug description

since a new case clause has been added to the settings.dataType-handling block, unfortunately, this branch will break the original code, the following code block which is used to handle settings.data will never get a chance to run.
### code snippet which reveals the bug

```
af.ajax({
  url: 'http://sample/do_query.jsonp?callback=?',
  type: 'get',
  data: {a: 1, b: 2},
  dataType: 'jsonp',
  success: function(data) {
    console.log(data);
  },
  error: function() {
    console.error(arguments);
  }
})
```

the requested url will always be `http://sample/do_query.jsonp?callback=json_callback1`, the `settings.data` has been omitted.
### how to fix?

switch the settings.dataType and settings.data code block.
