### PR TITLE
changed the returned value of width()/height() back to a number.

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1205,15 +1205,15 @@ if (!window.af || typeof(af) !== "function") {
                 if (val != nundefined)
                     return this.css("height", val);
                 if (this[0] == this[0].window)
-                    return window.innerHeight + '';
+                    return window.innerHeight;
                 if (this[0].nodeType == this[0].DOCUMENT_NODE)
-                    return this[0].documentElement.offsetHeight + '';
+                    return this[0].documentElement.offsetHeight;
                 else {
                     var tmpVal = this.css("height").replace("px", "");
                     if (tmpVal)
-                        return tmpVal;
+                        return +tmpVal;
                     else
-                        return this.offset().height + '';
+                        return this.offset().height;
                 }
             },
             /**
@@ -1230,15 +1230,15 @@ if (!window.af || typeof(af) !== "function") {
                 if (val != nundefined)
                     return this.css("width", val);
                 if (this[0] == this[0].window)
-                    return window.innerWidth + '';
+                    return window.innerWidth;
                 if (this[0].nodeType == this[0].DOCUMENT_NODE)
-                    return this[0].documentElement.offsetWidth + '';
+                    return this[0].documentElement.offsetWidth;
                 else {
                     var tmpVal = this.css("width").replace("px", "");
                     if (tmpVal)
-                        return tmpVal;
+                        return +tmpVal;
                     else
-                        return this.offset().width + '';
+                        return this.offset().width;
                 }
             },
             /**


### PR DESCRIPTION
**Note: this may not a bug, but I do think there is a better solution to handle the unity thing.**
### solution decription

there was [a older commit](https://github.com/01org/appframework/commit/a94fdadcb39e64dd7e5d4164384ad4e36bf2bdc5) from kyo-ago, I did not figure out why such a change has been made, after modification, the users who are familiar with jQuery will be strongly confused, and didn't see any benefit from that change.
Here is the [issue](https://github.com/01org/appframework/issues/483) created by me.
### how to do it better?

just convert the variable `tmpVal` from string to number via `+tmpVal`, so only number will be returned from `width()/height()` now, everybody's happy.
