### PR TITLE
fix a bug for browsers which are not based on webkit rendering engine.

### DIFF
--- a/ui/src/appframework.ui.js
+++ b/ui/src/appframework.ui.js
@@ -1680,7 +1680,7 @@
             }
 
             //insert backbutton (should optionally be left to developer..)
-            $(this.header).html('<a id="backButton" class="button"></a> <h1 id="pageTitle"></h1>' + header.innerHTML);
+            $(this.header).html('<a id="backButton" class="button"></a> <h1 id="pageTitle"></h1>' + this.header.innerHTML);
             this.backButton = $.query("#header #backButton").css("visibility", "hidden");
             $(document).on("click", "#header #backButton", function(e) {
                 e.preventDefault();


### PR DESCRIPTION
### bug discription

the `header.innerHTML` should be changed to `this.header.innerHTML` in line 1683, it will throw an error which **header is not defined** if you are not on Webkit, because the variable `header` hasn't be defined at all. 
The Webkit provides a shortcut for `document.getElementById(someId)`, that is `someId`, so, you're accidently correct on Webkit, if not, the code will break.
### how to reproduce?

test on any platforms rather than Webkit.
### how to fix?

change `header.innerHTML` to `this.header.innerHTML` in line 1683.
