### PR TITLE
$('body').append() will never execute script.

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1043,7 +1043,7 @@ if (!window.af || typeof(af) !== "function") {
                     return this;
                 if ($.isArray(element) || $.isObject(element))
                     element = $(element);
-                var i;
+                var i, node;
 
 
                 for (i = 0; i < this.length; i++) {
@@ -1055,10 +1055,15 @@ if (!window.af || typeof(af) !== "function") {
                         if (obj == nundefined || obj.length === 0) {
                             obj = document.createTextNode(element);
                         }
-                        if (obj.nodeName != nundefined && obj.nodeName.toLowerCase() == "script" && (!obj.type || obj.type.toLowerCase() === 'text/javascript')) {
-                            window['eval'](obj.innerHTML);
-                        } else if (obj instanceof $afm) {
-                            _insertFragments(obj, this[i], insert);
+                        if (obj instanceof $afm) {
+                            for (var k=0,lenk=obj.length; k<lenk; k++) {
+                            	node = obj[k];
+                            	if (node.nodeName != nundefined && node.nodeName.toLowerCase() == "script" && (!node.type || node.type.toLowerCase() === 'text/javascript')) {
+                            	    window['eval'](node.innerHTML);	
+                            	} else {
+                            	    _insertFragments($(node), this[i], insert);
+                            	}
+                            }	
                         } else {
                             insert != nundefined ? this[i].insertBefore(obj, this[i].firstChild) : this[i].appendChild(obj);
                         }


### PR DESCRIPTION
**Note: this might not be a bug, if you think it is a good idea to execute script in $(selector).append() just as jQuery does.**
### bug decription

the script which is appended to the DOM will never be executed.
### how to reproduce?

try this

```
af('body').append('<script>alert(1)</script>');
af('body').append('<div>this is newly added.</div><script>alert(2)</script>');
```
### how to fix?

the code below never get a chance to run.

```
if (obj.nodeName != nundefined 
    && obj.nodeName.toLowerCase() == "script" 
    && (!obj.type 
    || obj.type.toLowerCase() === 'text/javascript')) 
{
    window['eval'](obj.innerHTML);  
}
```

**because the obj is either a $afm instance or undefined, so the obj.nodeName will always be undefined.**
so I just changed the code logic to make it works, check it out.

a little more advice: if you do think it is really not a good idea to support this feature due to the performance of af, then just discard it.
