### PR TITLE
add one more option `jsonp` for $.ajax.

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1606,7 +1606,7 @@ if (!window.af || typeof(af) !== "function") {
             }
             var callbackName = 'jsonp_callback' + (++_jsonPID);
             var abortTimeout = "",
-                context;
+                context, callback;
             var script = document.createElement("script");
             var abort = function() {
                 $(script).remove();
@@ -1619,7 +1619,18 @@ if (!window.af || typeof(af) !== "function") {
                 delete window[callbackName];
                 options.success.call(context, data);
             };
-            script.src = options.url.replace(/=\?/, '=' + callbackName);
+            if (options.url.indexOf('callback=?') !== -1) {
+                script.src = options.url.replace(/=\?/, '=' + callbackName);
+            } else {
+                callback = options.jsonp ? options.jsonp : 'callback';
+                if (options.url.indexOf("?") === -1) {
+                    options.url += ("?" + callback + '=' + callbackName);
+                }
+                else {
+                    options.url += ("&" + callback + '=' + callbackName);
+                }
+                script.src = options.url;
+            }
             if (options.error) {
                 script.onerror = function() {
                     clearTimeout(abortTimeout);


### PR DESCRIPTION
### new features

add two features for af.
#### 1. user don't want to add callback=? to the url which is very inconvenient and unnecessary.

```
$.ajax({
  url: 'http:/example.com/group/swRightHP/do_query.jsonp?firstCatId=7&secCatId=727&leafCatId=1',
  type: 'get',
  data: {a: 1, b: 2},
  dataType: 'jsonp',
  success: function(data) {
       console.log(data);
   },
   error: function() {
       console.err(arguments);
   }
})
```

requested url: 
**http:/example.com/group/swRightHP/do_query.jsonp?firstCatId=7&secCatId=727&leafCatId=1&callback=jsonp_callback1**
#### 2. add one more option jsonp for $.ajax, so we can specify the name of the callback now.

```
$.ajax({
  url: 'http:/example.com/group/swRightHP/do_query.jsonp?firstCatId=7&secCatId=727&leafCatId=1',
  type: 'get',
  data: {a: 1, b: 2},
  dataType: 'jsonp',
  jsonp: 'myCallback',
  success: function(data) {
       console.log(data);
   },
   error: function() {
       console.err(arguments);
   }
})
```

-> requested url: **http:/example.com/group/swRightHP/do_query.jsonp?firstCatId=7&secCatId=727&leafCatId=1&myCallback=jsonp_callback1**

See also: http://api.jquery.com/jquery.ajax/
