### PR TITLE
Prevent slide when there is no menu

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -50,7 +50,7 @@
         
         $("#afui").bind("touchmove", function(e) {
             if(e.touches.length>1) return;
-
+            if (!$.ui.isSideMenuEnabled()) return true;
             if (!$.ui.slideSideMenu||keepOpen) return true;
 
             dx = e.touches[0].pageX;


### PR DESCRIPTION
## Issues 2.1

slide is possible when there is no menu `<nav>`
## Test Case

remove `<nav>` in kitchensink and try to swipe, notice that the panel slides away leaving a blank screen
## Fix

added `if (!$.ui.isSideMenuEnabled()) return true;` check in `af.slidemenu.js`
