### PR TITLE
apply back button trim only if length >= 7

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -984,7 +984,7 @@
          */
         setBackButtonText: function(text) {
             if(this._currentHeaderID!=="defaultHeader") return;
-            if (this.trimBackButtonText)
+            if (this.trimBackButtonText && text.length >= 7)
                 text = text.substring(0, 5) + "...";
             if (this.backButtonText.length > 0) $.query("#header header:not(.ignore) #backButton").html(this.backButtonText);
             else $.query("#header header:not(.ignore)  #backButton").html(text);


### PR DESCRIPTION
pull-request #512 for `2.1devtf` branch
## Issue

if backButton text is 5 characters then "..." is added, for example if text is "Title" becomes "Title..."
## Test Case

Make the title of a page to 5 character title, and navigate to a different page, notice that the bacButton has 5 characters + "..."
## Fix

add another check to append "..." only `if (text.length >= 7)` this will make sure that "..." is only appended if text is 7 characters or more, and truncates at 5 characters.
