### PR TITLE
convert $().data('someKey') to a json object if possible.

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1451,7 +1451,17 @@ if (!window.af || typeof(af) !== "function") {
             * @title $().data(key,[value]);
             */
             data: function(key, value) {
-                return this.attr('data-' + key, value);
+                var retData;
+                // setter
+                if (value) {
+                    return this.attr('data-' + key, value);
+                }
+                // getter
+                retData = this.attr('data-' + key);
+                try {
+                    retData = $.parseJSON(retData);
+                } catch(ex) {}
+                return retData;
             },
             /**
             * Rolls back the appframework elements when filters were applied


### PR DESCRIPTION
**Note: it might not be a bug, just make some improvement for `data()`**
### improvement description

now, the `data()` is using `attr()` internally which has no process to convert the result, even if the result is a json-like string.
### how to reproduce?

html

``` htm
<div id="test" data-x='{"c": 2, "d": [1, 2, 3], "e": {x: 1}}'></div>
```

js

``` js
console.log(af('#test').data('x'));
```
### how to do?

try to convert the result to a json object if possible, otherwise return the original result.
