### PR TITLE
fix slidemenu when widths are different

### DIFF
--- a/plugins/af.slidemenu.js
+++ b/plugins/af.slidemenu.js
@@ -20,15 +20,16 @@
 
         if ($.os.ie) return; //ie has the menu at the bottom
 
-
         var elems = $("#content, #header, #navbar");
         var max = 0;
         var slideOver = max/3;
         var transTime = $.ui.transitionTime;
         var openState=0;
         var showHideThresh=false;
-        var $cnt=$.query("#content");
-        var asideShown=false;
+        var $menu = $.query("#menu");
+        var $aside_menu = $.query("#aside_menu");
+        var menu_width = $menu.width();
+        var aside_width = $aside_menu.width();
         $("#afui").bind("touchstart", function(e) {
             openState=0;
             if (!$.ui.isSideMenuEnabled() && !$.ui.isAsideMenuEnabled()) return true;
@@ -46,18 +47,18 @@
             }
             else
                 doMenu = true;
-            max = parseInt($("#menu").width(),10);
-            slideOver=max/3;
+            
             var sidePos=$.ui.getSideMenuPosition();
-            if(sidePos>0)
+            if(sidePos>0){
                 openState=1;
-            else if(sidePos<0)
+                max = menu_width;
+            } else if(sidePos<0){
                 openState=2;
-            asideShown=$("#aside").css("display")==="block";
+                max = aside_width;
+            }
         });
 
         $("#afui").bind("touchmove", function(e) {
-        //    var sidePos=$.ui.getSideMenuPosition();
             if(e.touches.length>1) return;
             if (!$.ui.isSideMenuEnabled() && !$.ui.isAsideMenuEnabled()) return true;
             if (!$.ui.slideSideMenu||keepOpen) return true;
@@ -70,7 +71,6 @@
             if($.ui.splitview&&window.innerWidth>=parseInt($.ui.handheldMinWidth,10)&& (dx > startX)&&openState===0) return true;
             if (!$.ui.isSideMenuEnabled() && (dx > startX) && openState===0) return true;
             if (!$.ui.isAsideMenuEnabled() && (dx < startX) && openState===0) return true;
-
 
             if (Math.abs(dy - startY) > Math.abs(dx - startX)) return true;
 
@@ -85,30 +85,28 @@
             var thePlace = (dx - startX);
             if(openState===0){
                 if(thePlace<0){
-                    $("#aside_menu").show();
+                    max = aside_width;
+                    $aside_menu.show();
                     if(!$.ui.splitview)
-                        $("#menu").hide();
+                        $menu.hide();
                 } else {
-                    $("#menu").show();
-                    $("#aside_menu").hide();
+                    max = menu_width;
+                    $menu.show();
+                    $aside_menu.hide();
                 }
             }
-
-
+            
             if (Math.abs(thePlace) > max) return true;
-           // showHide = dx - startX > 0 ? 2 : false;
 
-
+            slideOver=max/3;
             showHideThresh=Math.abs(thePlace)<slideOver?showHide?showHide:false:2;
-
 
             if(openState===1) {
                 thePlace+=max;
                 showHideThresh=Math.abs(thePlace)<slideOver*2?showHide?showHide:false:2;
                 if(thePlace>max)
                     thePlace=max;
-            }
-            else if(openState===2){
+            } else if(openState===2){
                 thePlace=(-1*max)+thePlace;
                 showHideThresh=Math.abs(thePlace)<slideOver*2?showHide?showHide:false:2;
                 if(thePlace<(-1*max))


### PR DESCRIPTION
## 2.1 Issue

if slide menu widths are different then aside will slide more, this happens because the `max` value is based only on menu width, it should vary based on menu and aside_menu
## Test Case

In kitchen sink app, `setLeftSideMenuWidth(280)` and `setRightSideMenuWidth(200)` and then slide to open aside, notice that u can slide upto 280px, even though it is only 240
## Fix

made `max` value vary based on `#menu` width or `#aside_menu` width, depending on which side is slided
