### PR TITLE
Scrolling to top if content changed and is not exceeding panel height.

### DIFF
--- a/plugins/af.scroller.js
+++ b/plugins/af.scroller.js
@@ -908,10 +908,12 @@
             this.lastScrollInfo = scrollInfo;
             this.hasMoved = false;
 
-           if(this.elementInfo.maxTop==0&&this.elementInfo.maxLeft==0)
+            if(this.elementInfo.maxTop==0&&this.elementInfo.maxLeft==0){
                 this.currentScrollingObject=null;
-            else
+                this.scrollToTop(0);
+            }else{
                 this.scrollerMoveCSS(this.lastScrollInfo, 0);
+            }
 
         };
         jsScroller.prototype.getCSSMatrix = function (el) {

--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -1230,11 +1230,12 @@
             this.lastScrollInfo = scrollInfo;
             this.hasMoved = false;
 
-           if(this.elementInfo.maxTop==0&&this.elementInfo.maxLeft==0)
+            if(this.elementInfo.maxTop==0&&this.elementInfo.maxLeft==0){
                 this.currentScrollingObject=null;
-            else
+                this.scrollToTop(0);
+            }else{
                 this.scrollerMoveCSS(this.lastScrollInfo, 0);
-
+            }
         };
         jsScroller.prototype.getCSSMatrix = function (el) {
             if (this.androidFormsMode) {


### PR DESCRIPTION
Use case before fix/workaround:
1. A list that doesn't exceed the panel height, hence the scroller is disabled.
2. Hidden div gets shown by showHide() -> content exceeds panel height -> scroller enabled.
3. User scrolls down, top of the page not visible anymore. 
4. Hiding a div -> content NOT exceeding panel height -> scroller disabled, but top of the page still not visible.
5. Because the scroller is disabled it's not possible to get back to top of the page.

After fix/workaround:
1-4 see above
5. On the next touch the page scrolls to top.

I know this solution is not perfect, because it needs a second touch event after the some content get's hidden, but this doesn't render the panel useless at least.

Sorry for not minifying, I don't know how that's done. I hope you don't mind and can do that yourself.

This is my first pull request ever and the first commit to a repo other than my own. I hope I did everything the way it's supposed to be.

PS: Thanks for the best framework of all!
