### PR TITLE
Prevent `Uncaught TypeError: Cannot call method 'disable' of undefined`

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -1576,9 +1576,8 @@
                     }
                 }, numOnly(that.transitionTime) + 50);
             }
-            else
+            else if (typeof that.scrollingDivs[oldDiv.id] !== 'undefined')
                 that.scrollingDivs[oldDiv.id].disable();
-
 
         },
         /**


### PR DESCRIPTION
When i pulled the latest code into my 2.1 project, i ran into the mentioned error whenever navigating away from a panel that doesn't use scrolling. 

This is suggestion for a quick fix for the jscroller part, tested in chrome and on Galaxy Mini 2 (2.3.6).
