### PR TITLE
Make af.scroller.js pass jshint rule `eqeqeq=true`

### DIFF
--- a/plugins/af.scroller.js
+++ b/plugins/af.scroller.js
@@ -6,7 +6,6 @@
  * @copyright Intel
  * @param {function} $ Intel App Framework (af)
  */
- /* global af*/
  /* global numOnly*/
 (function ($) {
     "use strict";


### PR DESCRIPTION
Stricter Type comparisons should yield better performance.

Other changes:
- replaced occurences of global `af` as it's injected into the namespace explictly anyway
- some readability reformattings
