### PR TITLE
Set XHR requests to UTF-8 encoding by default

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1694,7 +1694,7 @@ if (!window.af || typeof(af) !== "function") {
                 if (!settings.url)
                     settings.url = window.location;
                 if (!settings.contentType)
-                    settings.contentType = "application/x-www-form-urlencoded";
+                    settings.contentType = "application/x-www-form-urlencoded; charset=UTF-8";
                 if (!settings.headers)
                     settings.headers = {};
 


### PR DESCRIPTION
Pretty much a standard for all other JavaScript frameworks
