### PR TITLE
Optimisation: Respect closure compiler type annotations / JS Doc fixes

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -577,7 +577,7 @@
          * @param {string} target
          * @param {string} value
          * @param {string=} position
-         * @param {(string|object)=} colro Color or CSS hash
+         * @param {(string=|object)} color Color or CSS hash
          * @title $.ui.updateBadge(target,value,[position],[color])
          */
         updateBadge: function(target, value, position, color) {
@@ -1265,7 +1265,7 @@
            ```
            $.ui.updateContentDiv("#myDiv","This is the new content");
            ```
-         * @param {(string, object)} id
+         * @param {(string|object)} id
          * @param {string} content HTML to update with
          * @title $.ui.updateContentDiv(id, content);
          */


### PR DESCRIPTION
- fixed a couple of formal errors, i.e. often there was something like `{Object, String}` instead of  `{(object|string)}` in the type hint, the variable name was mispelled or left out
- added a couple of missing `@params` to complete existing function doc blocks
- explicitely fixed annotations to use the type hint formats listed at https://developers.google.com/closure/compiler/docs/js-for-compiler (which are a subset of the official JSDOC spec).
