### PR TITLE
# fix fakeSelect text overflow (for issue #613)

### DIFF
--- a/plugins/css/af.selectBox.css
+++ b/plugins/css/af.selectBox.css
@@ -46,16 +46,19 @@
 	}
 
 	.afFakeSelect {
-		width:200px;
-		height:30px;
-		display:inline-block;
-		border:1px solid #ccc;
-		border-radius:5px;
-		line-height:2em;
-		font-size:1em;
-		padding-left:10px;
-		position:relative;
+		width: 200px;
+		height: 30px;
+		display: inline-block;
+		border: 1px solid #ccc;
+		border-radius: 5px;
+		line-height: 2em;
+		font-size: 1em;
+		padding-left: 10px;
+		position: relative;
 		padding-right: 35px;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;		
 	}
 
 	.afFakeSelect:after {


### PR DESCRIPTION
see #613 

this PR makes the fake select content cut-off nicely with text-ellipsis (...) just before the dropdown button
