### PR TITLE
Use $ passed to IIFE to avoid namespace collision

### DIFF
--- a/ayepromise.js
+++ b/ayepromise.js
@@ -176,6 +176,6 @@
     };
     return ayepromise;
 }));
-(function(){
+(function($){
     $.Deferred=ayepromise.defer;
 })(af);


### PR DESCRIPTION
In `ayepromise.js`, `af` was passed to an IIFE but not used, so the global `$` gets used instead.  When including jQuery, this overwrites the jQuery Deferred implementation.
