### PR TITLE
Popup: Fix default property typo

### DIFF
--- a/plugins/af.popup.js
+++ b/plugins/af.popup.js
@@ -56,7 +56,7 @@
                     };
                 this.id = opts.id = opts.id || $.uuid(); //opts is passed by reference
                 this.addCssClass = opts.addCssClass ? opts.addCssClass : "";
-                this.suppressTitle = opts.suppressTitle || opts.suppressTitle;
+                this.suppressTitle = opts.suppressTitle || this.suppressTitle;
                 this.title = opts.suppressTitle ? "" : (opts.title || "Alert");
                 this.message = opts.message || "";
                 this.cancelText = opts.cancelText || "Cancel";


### PR DESCRIPTION
Was wondering about the property  `supressTitle` in the object returned by `af.ui.popup({...})` - because it also had no effect whatsoever when specified in config array. `suppressTitle` works though ;)

So i corrected the typo and also made sure the prototype default value is correctly overriden on creation (otherwise i would get back an object with property `suppressTitle: false` although i'd set it to `true` on creation)
