### PR TITLE
Fixed Typo in $.ajax

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -1724,7 +1724,7 @@ if (!window.af || typeof(af) !== "function") {
             $.ajax(opts);
             ```
 
-        * @param {Object} opts Options
+        * @param {object} opts Options
         * @title $.ajax(options)
         */
         $.ajax = function(opts) {
@@ -1850,7 +1850,7 @@ if (!window.af || typeof(af) !== "function") {
                                 deferred.reject.call(context, xhr, "parsererror", error);
                             }
                             else {
-                                deferred.resolve.call(context, result, "succes", xhr);
+                                deferred.resolve.call(context, result, "success", xhr);
                                 settings.success.call(context, result, "success", xhr);
                             }
                         } else {


### PR DESCRIPTION
Not sure what this fixes - but it must fix _something_ ;) 

unsure though if that is the reason for the problem i was facing earlier today (failed to do oauth2 communication with `withCredendials: true` and  submitting "Authorization" headers with this implementation)
