### PR TITLE
ui.ready()-listeners may be removed when handled

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -475,7 +475,7 @@
             if (this.launchCompleted)
                 param();
             else {
-                $(document).on("afui:ready", function() {
+                $(document).one("afui:ready", function() {
                     param();
                 });
             }


### PR DESCRIPTION
`afui:ready` will only ever be triggered once - and so are our ready()-handlers also expected to (which is ensured by this PR).
