### PR TITLE
Fix issue with JSON

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -2048,6 +2048,9 @@ if (!window.af || typeof(af) !== "function") {
         * @title $.parseJSON(string)
         */
         $.parseJSON = function(string) {
+            if (typeof string === 'object') {
+                return object;
+            }
             return JSON.parse(string);
         };
 


### PR DESCRIPTION
JSON coming back from my webserver with response type application/json was coming to the parseJSON function as a JSON object already, so attempting to parse it again was causing bugs.

This happened since upgrading from 2.0.4

I might have missed the point or done something wrong, I haven't spent long investigating this so far
