### PR TITLE
Extend $.ui, instead of replacing it wholesale

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -2410,10 +2410,13 @@
         return (crc ^ (-1))>>>0;
     };
 
-    $.ui = new ui();
+    $.ui = $.extend($.ui || {}, new ui());
     $.ui.init=true;
-    $(window).trigger("afui:preinit");
-    $(window).trigger("afui:init");
+
+    setTimeout(function() {
+        $(window).trigger("afui:preinit");
+        $(window).trigger("afui:init");
+    }, 0);
 })(af);
 
 


### PR DESCRIPTION
Instead of clobbering `$.ui` (when `$` could be a reference to jQuery and `$.ui` to jQuery UI) - extend it, or an empty object.  Depending on namespace collisions, this should allow App Framework UI to interoperate with jQuery UI.

I'm not sure why the defer is necessary, but the app does not seem to load (using either AF or jQuery) otherwise.
