### PR TITLE
Patch $.ui.addContentDiv()

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -1344,8 +1344,17 @@
          * @title $.ui.addContentDiv(id, content, title);
          */
         addContentDiv: function(el, content, title, refresh, refreshFunc) {
-            el = typeof(el) !== "string" ? el : el.indexOf("#") === -1 ? "#" + el : el;
-            var myEl = $.query(el).get(0);
+            var myEl;
+            if(typeof(el) === "string") {
+                if(el.lastIndexOf("#", 1) === -1) el = "#" + el;
+                myEl = $.query(el).get(0);
+            } else if($.is$(el)) {
+                myEl = el.get(0);
+                el = myEl.id;
+            } else {
+                myEl = el;
+                el = myEl.id;
+            }
             var newDiv, newId;
             if (!myEl) {
                 newDiv = $.create("div", {


### PR DESCRIPTION
Allow `$.ui.addContentDiv()` to accept a pre-created DOM node as the first argument.

The bug:
This feature is suggested by the documentation as it indicates `el` may be a string or an object. However, `$.query()` only accepts a string, and no check is made to ensure that a node isn't passed. The following code will fail with "undefined is not a function" when `query` tries to strip the whitespace from the node object:

```
$.ui.addContentDiv($('<div>Stuff.</div>'));
```

The fix:
Add more checking to ensure that the `el` and `myEl` variables are set correctly. Now `el` may be a DOM id with or without the leading `#`, an element wrapped by `$`, or a naked element. The above test case will work as advertised.
