### PR TITLE
fixed typo

### DIFF
--- a/documentation/appframework/$.uuid.md
+++ b/documentation/appframework/$.uuid.md
@@ -28,7 +28,7 @@ undefined
 
 ##Detail
 
-$.uuid creates a psuedo GUID.  We uses this with plugins to create a unique id for each plugin
+$.uuid creates a psuedo GUID.  We use this with plugins to create a unique id for each plugin
 
 ```
 var id=$.uuid();


### PR DESCRIPTION
a minor fix to a typo in the description of the $.uuid() function
