### PR TITLE
Fixes #783

### DIFF
--- a/appframework.js
+++ b/appframework.js
@@ -865,8 +865,12 @@ if (!window.af || typeof(af) !== "function") {
             */
             removeProp: function(prop) {
                 var removePropFn=function(param) {
-                    if (that[i][param])
-                        that[i][param] = undefined;
+                    try {
+                        if (that[i][param]) {
+                            that[i][param] = undefined;
+                        }
+                    } catch(e) {}
+
                     if (that[i].afmCacheId && _propCache[that[i].afmCacheId]) {
                         delete _propCache[that[i].afmCacheId][prop];
                     }


### PR DESCRIPTION
try-catch-ignore-Fix to prevent NotSupportedError: DOM Exception on iOS8.1

Please notice fixed example:
http://dom.11com7.de/iaf/2014-11-07-prop-dom-error-9/fixed.htm (short: http://goo.gl/h1oZfQ)
