### PR TITLE
fixed name for scrollingDivs for func showModal

### DIFF
--- a/ui/appframework.ui.js
+++ b/ui/appframework.ui.js
@@ -1243,7 +1243,7 @@
                     modalParent.find("#modalFooter").hide();
                 }
 
-                this.scrollToTop("modal");
+                this.scrollToTop("modal_container");
                 modalDiv.data("panel", id);
                 var myPanel=$panel.get(0);
                 var fnc = myPanel.getAttribute("data-load");


### PR DESCRIPTION
for modal container correct name of scrollingDivs is "modal_container"
old code didn't scoll panel, and thus didn't display content