### PR TITLE
Make sure an active class is always set

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -970,6 +970,12 @@
 
                 setTimeout(function(){
                     active.removeClass("active");
+                    //Try to add the active class again (even though in most cases the class will already be set).
+                    //This solves an issue when swapping panels A->B->A by QUICKLY tapping footer buttons on slow devices.
+                    //Under these circumstances the timeout sometimes comes after the active classes to panels A and B have been set.
+                    //You may end up having no active panels (blank page).
+                    view.addClass("active");
+                    $(newDiv).addClass("active");
                 },50);
 
                 return;


### PR DESCRIPTION
Try to add the active class again (even though in most cases the class will already be set).
This solves an issue when swapping panels A->B->A by QUICKLY tapping footer buttons on slow devices.
Under these circumstances the timeout sometimes comes after the active classes to panels A and B have been set.
You may end up having no active panels (blank page).