### PR TITLE
Update af.ui.js

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -787,10 +787,12 @@
             var hash;
             if(typeof(ele)!=="string")
                 hash=$(ele).prop("id");
+            var tmp = view.find("footer").find("a").removeClass("pressed").attr("data-ignore-pressed","true");
+            //In case of a loadAjax being done:
+            tmp.filter("[href='"+hash+"']").addClass("pressed");
+            //In case of a loadDiv being done:
             hash="#"+hash;
-            //check if an item exists
-            if(view.find("footer").find("a").filter("[href='"+hash+"']").length===0) return;
-            view.find("footer").find("a").removeClass("pressed").attr("data-ignore-pressed","true").filter("[href='"+hash+"']").addClass("pressed");
+            tmp.filter("[href='"+hash+"']").addClass("pressed");
         },
 
          /**

--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -789,10 +789,10 @@
                 elementId=$(ele).prop("id");
             /*
             Check if an item exists:
-            Note that footer hrefs' may point to elements preceded by a # when trying to load a div (f.ex.: <footer href="#panelId">.
+            Note that footer hrefs' may point to elements preceded by a # when trying to load a div (f.ex.: <footer><a href="#panelId">).
             But in some other cases footer hrefs' may point to elements not preceded by a #
-                F.ex.: <footer href="ajaxRequest"> when doing ajax calls
-                F.ex.: <footer href="listX/itemY"> when using pushState routers - read more here: https://github.com/01org/appframework/issues/837
+                F.ex.: <footer><a href="ajaxRequest"> when doing ajax calls
+                F.ex.: <footer><a href="listX/itemY"> when using pushState routers - read more here: https://github.com/01org/appframework/issues/837
             We check whether an item exists including both options here (note the &&):
             */
             if((view.find("footer").find("a").filter("[href='"+elementId+"']").length===0)&&(view.find("footer").find("a").filter("[href='#"+elementId+"']").length===0)) return;

--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -787,19 +787,19 @@
             var elementId;
             if(typeof(ele)!=="string")
                 elementId=$(ele).prop("id");
-			/*
-			Check if an item exists:
-			Note that footer hrefs' may point to elements preceded by a # when trying to load a div (f.ex.: <footer href="#panelId">.
-			But in some other cases footer hrefs' may point to elements not preceded by a #
-				F.ex.: <footer href="ajaxRequest"> when doing ajax calls
-				F.ex.: <footer href="listX/itemY"> when using pushState routers - read more here: https://github.com/01org/appframework/issues/837
-			We check whether an item exists including both options here (note the &&):
-			*/
-			if((view.find("footer").find("a").filter("[href='"+elementId+"']").length===0)&&(view.find("footer").find("a").filter("[href='#"+elementId+"']").length===0)) return;
+            /*
+            Check if an item exists:
+            Note that footer hrefs' may point to elements preceded by a # when trying to load a div (f.ex.: <footer href="#panelId">.
+            But in some other cases footer hrefs' may point to elements not preceded by a #
+                F.ex.: <footer href="ajaxRequest"> when doing ajax calls
+                F.ex.: <footer href="listX/itemY"> when using pushState routers - read more here: https://github.com/01org/appframework/issues/837
+            We check whether an item exists including both options here (note the &&):
+            */
+            if((view.find("footer").find("a").filter("[href='"+elementId+"']").length===0)&&(view.find("footer").find("a").filter("[href='#"+elementId+"']").length===0)) return;
             var tmp = view.find("footer").find("a").removeClass("pressed").attr("data-ignore-pressed","true");
-			/*
-			Now we need to activate the elementId. We have to do this twice again. Once in case of loading a div using AF's router and once again in case of pushState routers or loading Ajax.
-			*/
+            /*
+            Now we need to activate the elementId. We have to do this twice again. Once in case of loading a div using AF's router and once again in case of pushState routers or loading Ajax.
+            */
             //In case of an Ajax call or if using a pushState router:
             tmp.filter("[href='"+elementId+"']").addClass("pressed");
             //In case of an loading a div with AF's internal router:

--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -784,15 +784,26 @@
          @title $.afui.setActiveTab
          */
         setActiveTab:function(ele,view){
-            var hash;
+            var elementId;
             if(typeof(ele)!=="string")
-                hash=$(ele).prop("id");
+                elementId=$(ele).prop("id");
+			/*
+			Check if an item exists:
+			Note that footer hrefs' may point to elements preceded by a # when trying to load a div (f.ex.: <footer href="#panelId">.
+			But in some other cases footer hrefs' may point to elements not preceded by a #
+				F.ex.: <footer href="ajaxRequest"> when doing ajax calls
+				F.ex.: <footer href="listX/itemY"> when using pushState routers - read more here: https://github.com/01org/appframework/issues/837
+			We check whether an item exists including both options here (note the &&):
+			*/
+			if((view.find("footer").find("a").filter("[href='"+elementId+"']").length===0)&&(view.find("footer").find("a").filter("[href='#"+elementId+"']").length===0)) return;
             var tmp = view.find("footer").find("a").removeClass("pressed").attr("data-ignore-pressed","true");
-            //In case of a loadAjax being done:
-            tmp.filter("[href='"+hash+"']").addClass("pressed");
-            //In case of a loadDiv being done:
-            hash="#"+hash;
-            tmp.filter("[href='"+hash+"']").addClass("pressed");
+			/*
+			Now we need to activate the elementId. We have to do this twice again. Once in case of loading a div using AF's router and once again in case of pushState routers or loading Ajax.
+			*/
+            //In case of an Ajax call or if using a pushState router:
+            tmp.filter("[href='"+elementId+"']").addClass("pressed");
+            //In case of an loading a div with AF's internal router:
+            tmp.filter("[href='#"+elementId+"']").addClass("pressed");
         },
 
          /**


### PR DESCRIPTION
Fix related with issue #837.

On first load of an Ajax Call, the href of the footer button will be = to the variable "hash" but without any hash character (#) at the beginning. Thus, the panel will correctly load with the results of an Ajax Call but the "pressed" class won't be added. The code tries to find an href having a # at the beginning (which is not the case on Ajax calls).

Last fix almost cleared all issues regarding footer buttons not being shown as pressed. Except for one case. If your app starts somewhere such as app.com/A then the footer button for "A" won't be shown as pressed in the first instance. Further clicks will work OK.

This fixes the issues for all cases.