### PR TITLE
Fixes issue #838. This patch makes it possible to use loadDiv both with ...

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -664,15 +664,19 @@
          */
         loadDiv: function(target, newView, back, transition,anchor) {
             // load a div
-            var newDiv = target.replace("#", "");
+            var newDiv = target;
 
+            var hashIndex = newDiv.indexOf("#");
             var slashIndex = newDiv.indexOf("/");
-            var hashLink = "";
-            if (slashIndex !== -1) {
-                // Ignore everything after the slash for loading
-                hashLink = newDiv.substr(slashIndex);
-                newDiv = newDiv.substr(0, slashIndex);
+            if ((slashIndex !== -1)&&(hashIndex !== -1)) {
+                //Ignore everything after the slash in the hash part of a URL
+                //For example: app.com/#panelid/option1/option2  will become -> app.com/#panelid
+                //For example: app.com/path/path2/path3  will still be -> app.com/path/path2/path3
+                if (slashIndex > hashIndex) {
+                    newDiv = newDiv.substr(0, slashIndex);
+                }
             }
+            newDiv = newDiv.replace("#", "");
 
             newDiv = $.query("#" + newDiv).get(0);
             if (!newDiv) {


### PR DESCRIPTION
This patch makes it possible to use loadDiv both with pushState routers and with internal AF router fixing issue #838.

loadDiv will now remove parameters (delimited in AF by a slash) only when those parameters come after a hash character. This way it is still possible to keep current AF functionality but still make it possible to be used with pushStateRouters simply calling loadDiv("path\/subpath", ...)

For example: app.com/#panelid/option1/option2  will become -> app.com/#panelid
But: app.com/path/path2/path3  will still be -> app.com/path/path2/path3

I tested kitchen sink and loadDiv still correctly wipes the "/foo/bar/something" part when loading appframework-master/#afuidemo/foo/bar/something