### PR TITLE
Do not handle back clicks when !useInternalRouting

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -1106,7 +1106,10 @@
                 }
             });
 
-            $(document).on("click", ".backButton, [data-back]", that.goBack.bind(that));
+            $(document).on("click", ".backButton, [data-back]", function() { 
+                if(that.useInternalRouting)
+                    that.goBack.bind(that);
+            });
             //Check for includes
 
             var items=$("[data-include]");


### PR DESCRIPTION
Do not handle back clicks when not using the internal router.
Similarly as we don't checkAnchorClick on "a" clicks when !useInternalRouting (line 1089).