### PR TITLE
"active" class not being removed from panels

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -879,14 +879,6 @@
          */
         runTransition: function(transition,previous,target, back,noTrans) {
 
-            if (typeof previous !== "undefined" && previous !== null) {
-                if(previous.find) {
-                    setTimeout(function(){
-                        previous.find(".active").removeClass("active");
-                    },500);
-                }
-            }
-            
             if(!transition)
                 transition="slide";
 


### PR DESCRIPTION
I ran into a situation where navigating using the anchor or loadContent approaches wasn't showing the correct panel. I noticed that the "active" class wasn't being removed from previous panels that had been viewed which was causing the issue.

I'm not sure this is the best approach, but it was the only solution I could come up with that worked. The removal of the class is in a timer so that the panel doesn't disappear before the transition completes.