### PR TITLE
also filter OPTION event targets

### DIFF
--- a/src/af.desktopBrowsers.js
+++ b/src/af.desktopBrowsers.js
@@ -32,7 +32,7 @@
      */
     var preventAllButInputs = function(event, target) {
         var tag = target.tagName.toUpperCase();
-        if (tag.indexOf("SELECT") > -1 || tag.indexOf("TEXTAREA") > -1 || tag.indexOf("INPUT") > -1) {
+        if (tag.indexOf("SELECT") > -1 || tag.indexOf("OPTION") > -1 || tag.indexOf("TEXTAREA") > -1 || tag.indexOf("INPUT") > -1) {
             return;
         }
         preventAll(event);


### PR DESCRIPTION
Allow event propagation not only for Select tags but also for its Option children. Without this change options were not selectable in older Firefox versions, rendering all Select elements unusable.