### PR TITLE
fixing issue with number of 'active' panels

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -945,6 +945,7 @@
             }
             else {
                 if(!back){
+                    $(hide).removeClass("active");
                     $(hide).trigger("panelunload");
                 }
                 else{


### PR DESCRIPTION
In a project, I used the *side-reveal* animation to go from one panel to another.
But I noticed that the number of 'active' panels on the page increases on each panel change.

This patch removes the 'active' class from the panel to hide, also when using the *-reveal* animations.

Thanks in advance for considering merging it.