### PR TITLE
avoid neverending spinning wheel ui mask, when operation is stalled

### DIFF
--- a/src/af.ui.js
+++ b/src/af.ui.js
@@ -116,6 +116,7 @@
     AFUi.prototype = {
         init:false,
         showLoading: true,
+        showingMask: false,
         loadingText: "Loading Content",
         remotePages: {},
         history: [],
@@ -602,6 +603,15 @@
             if (!text) text = this.loadingText || "";
             $.query("#afui_mask>h1").html(text);
             $.query("#afui_mask").show();
+            this.showingMask = true;
+
+            var self = this;
+            //set another timeout to auto-hide the mask if something goes wrong after 15 secs
+            setTimeout(function() {
+                 if(self.showingMask) {
+                    self.hideMask();
+                 }
+            }, 15000);
         },
         /**
          * Hide the loading mask
@@ -612,6 +622,7 @@
          */
         hideMask: function() {
             $.query("#afui_mask").hide();
+            this.showingMask = false;
         },
         /**
          * @api private


### PR DESCRIPTION
Sometimes the loading mask (spinning wheel) can stay forever on screen, if some long network operation for instance is stalled, since the code to hide the mask may never be called. This is really annoying from the user perspective as the app becomes basically unusable as we cannot get rid of it.
An easy way to avoid this is having a default timeout when we show the ui mask...and by controlling the status of the ui mask (showing or hidden) we can guarantee that we always hide it.