### PR TITLE
Fix panel active not remove between views and GoBack failure between different view.

### DIFF
--- a/src/af.lockscreen.js
+++ b/src/af.lockscreen.js
@@ -3,9 +3,9 @@
  * Copyright 2015 - Intel
  */
  
- /* global FastClick*/
+/** global FastClick **/
 
- /* jshint camelcase:false*/
+/** jshint camelcase:false **/
 
 
 (function($){
@@ -86,7 +86,7 @@
             $(item).on("touchstart",function(evt){
                 $(evt.target).addClass("touched");
             }).on("touchend",function(evt){
-                 $(evt.target).removeClass("touched");
+                $(evt.target).removeClass("touched");
             });
         },
         hide:function(){

--- a/src/af.swipereveal.js
+++ b/src/af.swipereveal.js
@@ -40,7 +40,7 @@
         target=$(e.target).closest(".swipe-content");
 
         width=target.closest(".swipe-reveal").find(".swipe-hidden").width();
-        if ($(e.target).parents('.swipe-content').length===0) {
+        if ($(e.target).parents(".swipe-content").length===0) {
             if($.getCssMatrix(e.target).e===0)
                 return ;
         }


### PR DESCRIPTION
1)Fix issues #850 #866 #873;
2)Fix explorer GoBack failed between different view;
3)Fix back button appended by code is invalid when 'click' on some device;
4)Add parameter 'back' to indicate whether transition is back in event 'panelunload' and 'panelload';
5)Code review for run 'grunt'

Major fixed issue is about panel active status between different views. Test case can use appframework DEMO. When loginview is modal, activated panel in 'mainview' is still active. After patching my code, the activated panel is remove.
For 'back' in event 'panelunload' and 'panelload', we can know whether transition is back.