### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ App Framework is a UI framework targeted at HTML5 browsers.
 
 Visit <http://app-framework-software.intel.com/index.php> for more information, documentation, and support.
 
-#2.2 support
+# 2.2 support
 Visit <http://app-framework-software.intel.com/af22/index.php> for App Framework 2.2 documentation.
 
-#3.0 version
+# 3.0 version
 
 The 3.0 version of App Framework removes the following
 
@@ -16,7 +16,7 @@ The 3.0 version of App Framework removes the following
 3. No longer provides a "Touchlayer", use Fastclick (https://github.com/ftlabs/fastclick) instead.
 4. Native scrolling is only used.  If you need a JS scroller, use an existing one like FTScroller (https://github.com/ftlabs/ftscroller) or iScroll
 
-##Note
+## Note
 You can still use App Framework 2 if you need Android <4 support or the query selector library.  The old query selector library *may* work with AF 3.0, but we do not test or support it.
 
 # Contribute
@@ -27,7 +27,7 @@ You can make changes to any of the files in the "src" directory
 
 
 
-#Building
+# Building
 
 We use Grunt to build our compiled files.  When you have made a change, run "grunt rebuild" to compile new source and minified files to include in your PR.
 

--- a/docs/af.ui/$.afui.actionsheet.md
+++ b/docs/af.ui/$.afui.actionsheet.md
@@ -1,4 +1,4 @@
-#$.afui.actionsheet()
+# $.afui.actionsheet()
 
 ```
 
@@ -6,7 +6,7 @@ This is a shorthand call to the $.actionsheet plugin.  We wire it to the afui di
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.actionsheet("Settings Logout")
@@ -27,14 +27,14 @@ This is a shorthand call to the $.actionsheet plugin.  We wire it to the afui di
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 links                         (string|Array.<string>)
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.autoLaunch.md
+++ b/docs/af.ui/$.afui.autoLaunch.md
@@ -1,4 +1,4 @@
-#$.afui.autoLaunch
+# $.afui.autoLaunch
 
 ```
 
@@ -6,7 +6,7 @@ Boolean if you want to auto launch afui
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.autoLaunch = false; //
@@ -14,13 +14,13 @@ Boolean if you want to auto launch afui
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.blockUI.md
+++ b/docs/af.ui/$.afui.blockUI.md
@@ -1,4 +1,4 @@
-#$.afui.blockUI(opacity)
+# $.afui.blockUI(opacity)
 
 ```
 
@@ -6,7 +6,7 @@ This will throw up a mask and block the UI
          
 ```
 
-##Example
+## Example
 
 ```
          $.afui.blockUI(.9)
@@ -14,14 +14,14 @@ This will throw up a mask and block the UI
 ```
 `
 
-##Parameters
+## Parameters
 
 ```
 opacity                       number
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.clearHistory.md
+++ b/docs/af.ui/$.afui.clearHistory.md
@@ -1,4 +1,4 @@
-#$.afui.clearHistory()
+# $.afui.clearHistory()
 
 ```
 
@@ -6,7 +6,7 @@ Clear the history queue for the current view based off the active div
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.clearHistory()
@@ -14,13 +14,13 @@ Clear the history queue for the current view based off the active div
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.disableTabBar.md
+++ b/docs/af.ui/$.afui.disableTabBar.md
@@ -1,4 +1,4 @@
-#$.afui.disableTabBar
+# $.afui.disableTabBar
 
 ```
 
@@ -6,7 +6,7 @@ This disables the tab bar ability to keep pressed states on elements
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.disableTabBar();
@@ -14,13 +14,13 @@ This disables the tab bar ability to keep pressed states on elements
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.drawer.show.md
+++ b/docs/af.ui/$.afui.drawer.show.md
@@ -1,4 +1,4 @@
-#$.afui.drawer.show
+# $.afui.drawer.show
 
 ```
 
@@ -6,7 +6,7 @@ This is a reference to the drawer plugin.
  
 ```
 
-##Example
+## Example
 
 ```
   $.afui.drawer.show('#left','left','reveal')
@@ -14,7 +14,7 @@ This is a reference to the drawer plugin.
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 id                            string
@@ -23,7 +23,7 @@ transition                    string
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.getTitle.md
+++ b/docs/af.ui/$.afui.getTitle.md
@@ -1,4 +1,4 @@
-#$.afui.getTitle
+# $.afui.getTitle
 
 ```
 
@@ -6,7 +6,7 @@ Get the title of the active header
          
 ```
 
-##Example
+## Example
 
 ```
          $.afui.getTitle()
@@ -14,13 +14,13 @@ Get the title of the active header
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.goBack.md
+++ b/docs/af.ui/$.afui.goBack.md
@@ -1,4 +1,4 @@
-#$.afui.goBack()
+# $.afui.goBack()
 
 ```
 
@@ -6,7 +6,7 @@ Initiate a back transition
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.goBack()
@@ -14,14 +14,14 @@ Initiate a back transition
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 delta                         number=
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.hideMask.md
+++ b/docs/af.ui/$.afui.hideMask.md
@@ -1,4 +1,4 @@
-#$.afui.hideMask();
+# $.afui.hideMask();
 
 ```
 
@@ -6,7 +6,7 @@ Hide the loading mask
   
 ```
 
-##Example
+## Example
 
 ```
   $.afui.hideMask();
@@ -14,13 +14,13 @@ Hide the loading mask
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.launch.md
+++ b/docs/af.ui/$.afui.launch.md
@@ -1,4 +1,4 @@
-#$.afui.launch();
+# $.afui.launch();
 
 ```
 
@@ -7,7 +7,7 @@ If autoLaunch is set to false, you can manually invoke it.
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.autoLaunch=false;
@@ -16,13 +16,13 @@ If autoLaunch is set to false, you can manually invoke it.
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.loadContent.md
+++ b/docs/af.ui/$.afui.loadContent.md
@@ -1,4 +1,4 @@
-#$.afui.loadContent(target, newTab, goBack, transition, anchor);
+# $.afui.loadContent(target, newTab, goBack, transition, anchor);
 
 ```
 
@@ -7,7 +7,7 @@ We can pass in a hash+id or URL.
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.loadContent("#main",false,false,"up");
@@ -15,7 +15,7 @@ We can pass in a hash+id or URL.
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 target                        string
@@ -26,7 +26,7 @@ anchor                        object=
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.loadDefaultHash.md
+++ b/docs/af.ui/$.afui.loadDefaultHash.md
@@ -1,4 +1,4 @@
-#$.afui.loadDefaultHash
+# $.afui.loadDefaultHash
 
 ```
 
@@ -6,7 +6,7 @@ This is a boolean property.  When set to true (default) it will load that panel 
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.loadDefaultHash=false; //Never load the page from the hash when the app is started
@@ -15,13 +15,13 @@ This is a boolean property.  When set to true (default) it will load that panel 
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.manageHistory.md
+++ b/docs/af.ui/$.afui.manageHistory.md
@@ -1,4 +1,4 @@
-#$.afui.manageHistory
+# $.afui.manageHistory
 
 ```
 
@@ -6,7 +6,7 @@ This is a boolean property.   When set to true, we manage history and update the
    
 ```
 
-##Example
+## Example
 
 ```
   $.afui.manageHistory=false;//Don't manage for apps using Backbone
@@ -14,13 +14,13 @@ This is a boolean property.   When set to true, we manage history and update the
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.popup.md
+++ b/docs/af.ui/$.afui.popup.md
@@ -1,4 +1,4 @@
-#$.afui.popup(opts)
+# $.afui.popup(opts)
 
 ```
 
@@ -6,7 +6,7 @@ This is a wrapper to $.popup.js plugin.  If you pass in a text string, it acts l
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.popup(opts);
@@ -24,14 +24,14 @@ This is a wrapper to $.popup.js plugin.  If you pass in a text string, it acts l
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 options                       (object|string)
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.ready.md
+++ b/docs/af.ui/$.afui.ready.md
@@ -1,4 +1,4 @@
-#$.afui.ready
+# $.afui.ready
 
 ```
 
@@ -6,7 +6,7 @@ function to fire when afui is ready and completed launch
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.ready(function(){console.log('afui is ready');});
@@ -14,14 +14,14 @@ function to fire when afui is ready and completed launch
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 param                         function
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.registerDataDirective.md
+++ b/docs/af.ui/$.afui.registerDataDirective.md
@@ -1,4 +1,4 @@
-#$.afui.registerDataDirective
+# $.afui.registerDataDirective
 
 ```
 
@@ -7,7 +7,7 @@ html based execution (see af.popup.js)
          
 ```
 
-##Example
+## Example
 
 ```
          $.afui.registerDataDirective("[data-foo]",function(){
@@ -17,7 +17,7 @@ html based execution (see af.popup.js)
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 selector                      string
@@ -25,7 +25,7 @@ callback                      function
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.removeBadge.md
+++ b/docs/af.ui/$.afui.removeBadge.md
@@ -1,4 +1,4 @@
-#$.afui.removeBadge(target)
+# $.afui.removeBadge(target)
 
 ```
 
@@ -6,7 +6,7 @@ Removes a badge from the selected target.
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.removeBadge("#mydiv");
@@ -14,14 +14,14 @@ Removes a badge from the selected target.
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 target                        string
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.setBackButtonText.md
+++ b/docs/af.ui/$.afui.setBackButtonText.md
@@ -1,4 +1,4 @@
-#$.afui.setBackButtonText(title)
+# $.afui.setBackButtonText(title)
 
 ```
 
@@ -6,7 +6,7 @@ set the back button text
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.setBackButtonText("about");
@@ -14,14 +14,14 @@ set the back button text
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 text                          string
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.setBackButtonVisbility.md
+++ b/docs/af.ui/$.afui.setBackButtonVisbility.md
@@ -1,4 +1,4 @@
-#$.afui.setBackButtonVisbility
+# $.afui.setBackButtonVisbility
 
 ```
 
@@ -6,7 +6,7 @@ Set the visibility of the back button for the current header
          
 ```
 
-##Example
+## Example
 
 ```
          $.afui.setBackButtonVisbility(true)
@@ -14,14 +14,14 @@ Set the visibility of the back button for the current header
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 Boolean                       boolean
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.setTitle.md
+++ b/docs/af.ui/$.afui.setTitle.md
@@ -1,4 +1,4 @@
-#$.afui.setTitle
+# $.afui.setTitle
 
 ```
 
@@ -6,7 +6,7 @@ Set the title of the active header from
          
 ```
 
-##Example
+## Example
 
 ```
          $.afui.setTitle("New Title")
@@ -14,14 +14,14 @@ Set the title of the active header from
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 String                        string|object
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.showMask.md
+++ b/docs/af.ui/$.afui.showMask.md
@@ -1,4 +1,4 @@
-#$.afui.showMask(text, value);
+# $.afui.showMask(text, value);
 
 ```
 
@@ -6,7 +6,7 @@ Show the loading mask with specificed text
 
 ```
 
-##Example
+## Example
 
 ```
  $.afui.showMask()
@@ -16,7 +16,7 @@ Show the loading mask with specificed text
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 text                          string=
@@ -24,7 +24,7 @@ value                         number=
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.unblockUI.md
+++ b/docs/af.ui/$.afui.unblockUI.md
@@ -1,4 +1,4 @@
-#$.afui.unblockUI()
+# $.afui.unblockUI()
 
 ```
 
@@ -6,7 +6,7 @@ This will remove the UI mask
          
 ```
 
-##Example
+## Example
 
 ```
          $.afui.unblockUI()
@@ -14,13 +14,13 @@ This will remove the UI mask
 ```
 `
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.updateBadge.md
+++ b/docs/af.ui/$.afui.updateBadge.md
@@ -1,4 +1,4 @@
-#$.afui.updateBadge(target,value,[position],[color])
+# $.afui.updateBadge(target,value,[position],[color])
 
 ```
 
@@ -10,7 +10,7 @@ Update a badge on the selected target.  Position can be
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.updateBadge("#mydiv","3","bl","green");
@@ -18,7 +18,7 @@ Update a badge on the selected target.  Position can be
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 target                        string
@@ -28,7 +28,7 @@ color                         (string=|object)
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/af.ui/$.afui.useAjaxCacheBuster.md
+++ b/docs/af.ui/$.afui.useAjaxCacheBuster.md
@@ -1,4 +1,4 @@
-#$.afui.useAjaxCacheBuster
+# $.afui.useAjaxCacheBuster
 
 ```
 
@@ -7,7 +7,7 @@ This is a boolean that when set to true will add "&amp;cache=rand" to any ajax l
  
 ```
 
-##Example
+## Example
 
 ```
  $.afui.useAjaxCacheBuster=true;
@@ -15,13 +15,13 @@ This is a boolean that when set to true will add "&amp;cache=rand" to any ajax l
 ```
 
 
-##Parameters
+## Parameters
 
 ```
 
 ```
 
-##Returns
+## Returns
 
 ```
 undefined

--- a/docs/plugins/af.actionsheet.md
+++ b/docs/plugins/af.actionsheet.md
@@ -1,4 +1,4 @@
-#actionsheet
+# actionsheet
 
 The actionsheet plugin enables developers create an action sheet for the user to interact with.  We always add a last "Cancel" option to the actionsheet.
 

--- a/docs/plugins/af.animateheader.md
+++ b/docs/plugins/af.animateheader.md
@@ -1,4 +1,4 @@
-#animateheader
+# animateheader
 
 This plugin will animate headers during transitions. Simply include the script to enable header animations during panel transitions.
 

--- a/docs/plugins/af.animation.md
+++ b/docs/plugins/af.animation.md
@@ -1,4 +1,4 @@
-#animation
+# animation
 
 This plugin lets you run class based animations and keep the class, reverse them, run a function after it's finished, etc.
 

--- a/docs/plugins/af.drawer.md
+++ b/docs/plugins/af.drawer.md
@@ -1,4 +1,4 @@
-#drawer
+# drawer
 
 This plugin enables drawers (side menus) in your application.  The drawers must be &lt;nav> items in the same view.
 

--- a/docs/plugins/af.lockscreen.md
+++ b/docs/plugins/af.lockscreen.md
@@ -1,4 +1,4 @@
-#Lockscreen
+# Lockscreen
 
 The lockscreen enables developers of hybrid apps to present a lock screen to users.
 Users are required to enter a 4 digit pin to unlock it.  This can easily be bypassed

--- a/docs/plugins/af.popup.md
+++ b/docs/plugins/af.popup.md
@@ -1,4 +1,4 @@
-#Popup
+# Popup
 
 The popup plugin allows you to creat your own stylized popup with App Framework.  It is non-blocking and allows more flexibility then native dialogs.  You can use this plugin to show messages, options, or even login forms.
 
@@ -185,7 +185,7 @@ setTimeout(function(){
 },3000);
 ```
 
-###Directive example
+### Directive example
 
 
 ```

--- a/docs/plugins/af.splashscreen.md
+++ b/docs/plugins/af.splashscreen.md
@@ -1,4 +1,4 @@
-#Splashscreen
+# Splashscreen
 
 This plugin will hide a splashscreen when the $.afui.ready has triggered.  Simply include the script and it will remove the div with id="splashscreen"
 

--- a/docs/plugins/af.swipereveal.md
+++ b/docs/plugins/af.swipereveal.md
@@ -1,4 +1,4 @@
-#swipe to reveal
+# swipe to reveal
 
 The swipe to reveal allows you to swipe an object and reveal another.  This is useful for "swipe to delete" implementations
 
@@ -6,7 +6,7 @@ To use this, simply include the js plugin and css file.
 
 
 
-##Using
+## Using
 
 To use the plugin, add the class "swipe-reveal" to your container DOM node.  Inside the container should be two elements, the first with the content you want to show with class "swipe-content".  The second is the content to reveal with class "swipe-hidden"
 

--- a/docs/plugins/af.toast.md
+++ b/docs/plugins/af.toast.md
@@ -1,4 +1,4 @@
-#Toast
+# Toast
 
 The toast plugin enables developers to deliver toast style messages to users
 
@@ -79,7 +79,7 @@ Just display a message
 $.afui.toast("Hello World");
 ```
 
-###Directive example
+### Directive example
 
 Here we will dismiss the actionsheet in 5 seconds if there is no response from the user
 

--- a/docs/plugins/af.touchevents.md
+++ b/docs/plugins/af.touchevents.md
@@ -1,11 +1,11 @@
-#Touch Events
+# Touch Events
 
 This plugin adds additional touch events that you can register to listen for.  Simply include the plugin and it will do the rest.  We do not call preventDefault or stopPropagation on any events.
 
-##NOTE
+## NOTE
 
 
-##Events
+## Events
 
 ```
 tap                  Tap on the element
@@ -23,7 +23,7 @@ swipeUpStart         A swipe up has been started
 swipeDownStart       A swipe down has been started
 ```
 
-##Listening
+## Listening
 
 You can listen for any of the events like any other event
 

--- a/docs/plugins/af.transform.md
+++ b/docs/plugins/af.transform.md
@@ -1,4 +1,4 @@
-#transform
+# transform
 
 This plugin lets you run transition based animations via css3 transforms.
 

--- a/samples/angular/readme.md
+++ b/samples/angular/readme.md
@@ -1,3 +1,3 @@
-#sample
+# sample
 
 This sample is to show basic usage of Angular and App Framework UI.  This does not go into more advanced features, such as page routing/navigation.   The key takeway is delaying the loading of Angular until App Framework UI has been dispatched for loading the "partials" in App Framework UI.  This also shows using a directive for the "longTap" event App Framework UI dispatches.

--- a/samples/backbone/readme.md
+++ b/samples/backbone/readme.md
@@ -1,3 +1,3 @@
-#sample
+# sample
 
 This sample is to show basic usage of Backbone and App Framework UI.  This does not go into more advanced features, such as page routing/navigation.  This shows initiating the view when App Framework UI is ready, and responding to a custom "longTap" event.

--- a/samples/react/readme.md
+++ b/samples/react/readme.md
@@ -1,3 +1,3 @@
-#sample
+# sample
 
 This sample is to show basic usage of React and App Framework UI.  This does not go into more advanced features, such as page routing/navigation.  This shows how to create custom React components and load them in an App Framework UI app, along with responding to custom "longTap" events.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
